### PR TITLE
feat(pr): add comprehensive PR subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,8 +226,278 @@ Cloud may require trash then purge.
 
 ---
 
+## Bitbucket PR Commands Analysis (2024-12-18)
+
+### Current atl pr Commands (IMPLEMENTED)
+
+```
+atl pr
+├── list        # List PRs (--state, --author, --limit, --json, --web)
+├── view        # View PR details (--json, --web)
+├── diff        # View raw diff
+├── comment     # Add comment
+├── status      # PRs relevant to you (created/reviewing)
+├── merge       # Merge PR (--force, --delete-branch)
+├── create      # Create PR (--title, --body, --base, --head, --reviewer, --fill, --web)
+├── checkout    # Checkout PR locally (-b, --detach, -f) [alias: co]
+├── review      # Review PR (--approve, --request-changes, --comment, --body)
+├── approve     # Approve PR
+├── unapprove   # Remove approval
+├── decline     # Decline/close PR (--comment) [alias: close]
+├── reopen      # Reopen declined PR
+├── edit        # Edit PR (--title, --body, --base, --add-reviewer, --remove-reviewer)
+├── rebase      # Server-side rebase
+├── commits     # List PR commits (--limit, --json)
+├── files       # List changed files (--limit, --json) [alias: changes]
+├── activity    # Show PR activity (--limit, --json)
+└── can-merge   # Check merge status (--json)
+```
+
+### gh pr Commands (Reference)
+
+```
+gh pr
+├── create      # ← atl: ✓
+├── list        # ← atl: ✓
+├── view        # ← atl: ✓
+├── diff        # ← atl: ✓
+├── status      # ← atl: ✓
+├── checkout    # ← atl: ✓
+├── checks      # GitHub Actions specific, skip
+├── close       # ← atl: "decline"
+├── comment     # ← atl: ✓
+├── edit        # ← atl: "update metadata"
+├── merge       # ← atl: ✓
+├── ready       # draft PR concept
+├── reopen      # ← atl: ✓
+├── review      # ← atl: approve/unapprove/needs-work
+├── lock/unlock # not in BB API
+└── update-branch # ← atl: `rebase`
+```
+
+### Bitbucket Server API Capabilities
+
+From `docs/api-specs/bitbucketserver.906.postman.json`:
+
+| Endpoint | Purpose | atl Status |
+|----------|---------|------------|
+| Create pull request | POST .../pull-requests | ✓ |
+| Get pull request | GET .../pull-requests/{id} | ✓ |
+| Update pull request metadata | PUT .../pull-requests/{id} | ✓ |
+| Delete pull request | DELETE .../pull-requests/{id} | missing |
+| Approve pull request | POST .../participants | ✓ |
+| Unapprove pull request | DELETE .../participants | ✓ |
+| Decline pull request | POST .../decline | ✓ |
+| Re-open pull request | POST .../reopen | ✓ |
+| Merge pull request | POST .../merge | ✓ |
+| Rebase pull request | POST .../rebase | ✓ |
+| Test if can merge | GET .../merge | ✓ |
+| Get pull request commits | GET .../commits | ✓ |
+| Gets pull request changes | GET .../changes | ✓ |
+| Get pull request activity | GET .../activity | ✓ |
+| Stream raw diff | GET .../diff | ✓ |
+| Change participant status | PUT .../participants/{user} | ✓ |
+| Watch/Unwatch | POST/DELETE .../watch | missing |
+| Auto-merge settings | GET/POST/DELETE .../auto-merge | missing |
+
+### Feature Matrix (Updated)
+
+```
+Command          gh    atl   BB API   Status
+─────────────────────────────────────────────────
+create           ✓     ✓     ✓        DONE
+checkout         ✓     ✓     -        DONE
+approve/review   ✓     ✓     ✓        DONE
+decline          ✓     ✓     ✓        DONE
+reopen           ✓     ✓     ✓        DONE
+edit             ✓     ✓     ✓        DONE
+commits          ✓     ✓     ✓        DONE
+files/changes    ✓     ✓     ✓        DONE
+rebase           -     ✓     ✓        DONE
+can-merge        -     ✓     ✓        DONE
+activity         -     ✓     ✓        DONE
+watch            -     ✗     ✓        TODO (low priority)
+auto-merge       ✓     ✗     ✓        TODO (low priority)
+```
+
+### gh Patterns Worth Adopting
+
+1. **`--json <fields>`** - Scriptable output
+   ```bash
+   atl pr list --json id,title,author | jq '.[] | select(.author=="me")'
+   ```
+
+2. **`--web` / `-w`** - Open in browser
+   ```bash
+   atl pr view 123 --web  # opens Bitbucket URL
+   ```
+
+3. **Review workflow flags** - Mutually exclusive
+   ```bash
+   atl pr review 123 --approve
+   atl pr review 123 --request-changes -b "fix the tests"
+   atl pr review 123 --comment -b "LGTM"
+   ```
+
+4. **Smart arg parsing** - Accept ID, URL, or branch
+   ```bash
+   atl pr view 123
+   atl pr view https://bitbucket.example.com/.../pull-requests/123
+   atl pr view feature/foo  # find PR by source branch
+   ```
+
+5. **Content input patterns**
+   - `-t/--title`, `-b/--body` direct flags
+   - `-F/--body-file` for file input (stdin with `-`)
+   - `--fill` auto-fill from commits
+   - `-e/--editor` interactive editor
+
+### API Methods to Add
+
+```go
+// api/bitbucket.go
+
+func (c *BitbucketClient) ApprovePullRequest(ctx, project, repo string, prID, version int) error
+func (c *BitbucketClient) UnapprovePullRequest(ctx, project, repo string, prID, version int) error
+func (c *BitbucketClient) SetReviewerStatus(ctx, project, repo string, prID int, user, status string) error
+func (c *BitbucketClient) DeclinePullRequest(ctx, project, repo string, prID, version int) error
+func (c *BitbucketClient) ReopenPullRequest(ctx, project, repo string, prID, version int) error
+func (c *BitbucketClient) UpdatePullRequest(ctx, project, repo string, prID int, opts UpdatePROptions) error
+func (c *BitbucketClient) GetPullRequestCommits(ctx, project, repo string, prID int) ([]Commit, error)
+func (c *BitbucketClient) GetPullRequestChanges(ctx, project, repo string, prID int) ([]Change, error)
+func (c *BitbucketClient) CanMerge(ctx, project, repo string, prID int) (bool, error)
+func (c *BitbucketClient) RebasePullRequest(ctx, project, repo string, prID, version int) error
+```
+
+### Command Designs
+
+**pr create**
+```
+atl pr create [project/repo]
+  -t, --title        PR title (required unless --fill)
+  -b, --body         PR description
+  -B, --base         Target branch (default: main/master)
+  -H, --head         Source branch (default: current branch)
+  -r, --reviewer     Add reviewer (repeatable)
+  -a, --assignee     Add assignee (repeatable)
+  -d, --draft        Create as draft
+  -w, --web          Open in browser after creation
+  --fill             Auto-fill title/body from commits
+```
+
+**pr checkout**
+```
+atl pr checkout <pr-id>
+  # git fetch origin pull/{id}/head:pr-{id} && git checkout pr-{id}
+  # or for BB: git fetch origin refs/pull-requests/{id}/from:pr-{id}
+```
+
+**pr review**
+```
+atl pr review <pr-id>
+  -a, --approve           Approve the PR
+  -r, --request-changes   Request changes (sets NEEDS_WORK)
+  -c, --comment           Add review comment only
+  -b, --body              Review comment text
+  -F, --body-file         Read body from file
+```
+
+**pr decline**
+```
+atl pr decline <pr-id>
+  -c, --comment    Decline reason
+```
+
+**pr edit**
+```
+atl pr edit <pr-id>
+  -t, --title       New title
+  -b, --body        New description
+  -B, --base        Change target branch
+  --add-reviewer    Add reviewer
+  --remove-reviewer Remove reviewer
+```
+
+### Bitbucket API Notes
+
+**Participant Status Values:**
+- `UNAPPROVED` - default, no action taken
+- `APPROVED` - approved the PR
+- `NEEDS_WORK` - requested changes
+
+**PR Ref Format:**
+```
+refs/pull-requests/{id}/from   # source branch
+refs/pull-requests/{id}/merge  # merge preview
+```
+
+**Version Field:**
+All mutating operations require `version` from GET response (optimistic locking).
+
+---
+
+## Decision Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2024-12-03 | Keep flat cmd/ for now, refactor incrementally | Avoid big-bang refactor, ship delete first |
+| 2024-12-03 | Add --yes flag, require confirmation by default | gh-cli pattern, prevents accidents |
+| 2024-12-03 | Support ID/title/URL for delete target | Consistent with create --parent |
+| 2024-12-03 | Skip Factory pattern for now | Overkill at current scale |
+| 2024-12-18 | Priority: pr create > checkout > review > decline | Completes daily workflow |
+| 2024-12-18 | Adopt gh --json/--web patterns | Scriptability + browser fallback |
+| 2024-12-18 | Skip lock/unlock, checks (GitHub-specific) | Not in BB API |
+| 2024-12-18 | Implemented all high/medium priority PR commands | 19 total subcommands |
+
+---
+
+## Implementation Summary (2024-12-18)
+
+### New Files Created
+- `cmd/pr_create.go` - Create PR with --fill, --reviewer, --web
+- `cmd/pr_checkout.go` - Local checkout with alias `co`
+- `cmd/pr_review.go` - Review/approve/unapprove commands
+- `cmd/pr_lifecycle.go` - Decline, reopen, rebase commands
+- `cmd/pr_edit.go` - Edit title/body/reviewers
+- `cmd/pr_info.go` - Commits, files, activity, can-merge commands
+- `cmd/browser.go` - Cross-platform `--web` opener
+
+### API Methods Added (api/bitbucket.go)
+- `ApprovePullRequest`, `UnapprovePullRequest`
+- `SetReviewerStatus` (NEEDS_WORK support)
+- `DeclinePullRequest`, `ReopenPullRequest`
+- `UpdatePullRequest` with UpdatePROptions
+- `GetPullRequestCommits`, `GetPullRequestChanges`
+- `GetPullRequestActivity`
+- `CanMerge`, `RebasePullRequest`
+- `AddReviewer`, `RemoveReviewer`
+- `GetDefaultBranch`
+- `DeleteBranch` (Branch Utils)
+
+### Patterns Applied
+- `--json` output on list/view/commits/files/activity/can-merge
+- `--web` flag to open in browser
+- Consistent arg parsing: `[project/repo] <pr-id>`
+- Mutually exclusive flags for review actions
+
+### Post-implementation Fixes
+See `docs/devlog/2024-12-18-pr-commands.org` for detailed lessons learned.
+
+Summary:
+1. No lying flags - implement or delete
+2. Safe git ops - never merge into current branch
+3. Exclusive output modes - --web vs --json
+4. HTTP hygiene - close bodies, set Accept header
+5. Flag validation - enforce required combinations
+6. Cross-platform browser - OS detection
+7. Branch normalization - handle refs/heads/ prefix
+
+---
+
 ## Next Steps
 
 1. Add `page delete` command with confirmation
 2. Add `cmdutil.Confirm()` and spinner helpers
-3. Consider restructure after more commands exist
+3. Add `pr watch`/`unwatch` (low priority)
+4. Add `pr auto-merge` settings (low priority)
+5. Consider restructure after more commands exist

--- a/cmd/browser.go
+++ b/cmd/browser.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}

--- a/cmd/pr_checkout.go
+++ b/cmd/pr_checkout.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var prCheckoutCmd = &cobra.Command{
+	Use:   "checkout <pr-id>",
+	Short: "Check out a pull request branch locally",
+	Long: `Check out the source branch of a pull request locally.
+
+This fetches the PR's source branch and creates a local branch named pr-<id>.`,
+	Aliases: []string{"co"},
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		prIDStr := args[0]
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		project, repo, err := parseRepoArg("")
+		if err != nil {
+			return fmt.Errorf("could not determine repository: %w", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		pr, err := client.GetPullRequest(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("fetching PR: %w", err)
+		}
+
+		sourceBranch := pr.FromRef.DisplayID
+		localBranch := fmt.Sprintf("pr-%d", prID)
+
+		detach, _ := cmd.Flags().GetBool("detach")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if branchName != "" {
+			localBranch = branchName
+		}
+
+		force, _ := cmd.Flags().GetBool("force")
+
+		fmt.Printf("Fetching PR #%d: %s\n", prID, pr.Title)
+		fmt.Printf("  %s -> %s\n", pr.FromRef.DisplayID, pr.ToRef.DisplayID)
+
+		fetchCmd := exec.Command("git", "fetch", "origin", sourceBranch)
+		fetchCmd.Stdout = os.Stdout
+		fetchCmd.Stderr = os.Stderr
+		if err := fetchCmd.Run(); err != nil {
+			return fmt.Errorf("fetching branch: %w", err)
+		}
+
+		if detach {
+			checkoutCmd := exec.Command("git", "checkout", "--detach", "FETCH_HEAD")
+			checkoutCmd.Stdout = os.Stdout
+			checkoutCmd.Stderr = os.Stderr
+			if err := checkoutCmd.Run(); err != nil {
+				return fmt.Errorf("checking out: %w", err)
+			}
+			fmt.Printf("Checked out PR #%d in detached HEAD state\n", prID)
+			return nil
+		}
+
+		if force {
+			checkoutCmd := exec.Command("git", "checkout", "-B", localBranch, "FETCH_HEAD")
+			checkoutCmd.Stdout = os.Stdout
+			checkoutCmd.Stderr = os.Stderr
+			if err := checkoutCmd.Run(); err != nil {
+				return fmt.Errorf("checking out: %w", err)
+			}
+			fmt.Printf("Switched to branch '%s'\n", localBranch)
+			return nil
+		}
+
+		if branchExists(localBranch) {
+			checkoutCmd := exec.Command("git", "checkout", localBranch)
+			checkoutCmd.Stdout = os.Stdout
+			checkoutCmd.Stderr = os.Stderr
+			if err := checkoutCmd.Run(); err != nil {
+				return fmt.Errorf("checking out: %w", err)
+			}
+
+			mergeCmd := exec.Command("git", "merge", "--ff-only", "FETCH_HEAD")
+			mergeCmd.Stdout = os.Stdout
+			mergeCmd.Stderr = os.Stderr
+			if err := mergeCmd.Run(); err != nil {
+				return fmt.Errorf("could not fast-forward %q; use --force to overwrite: %w", localBranch, err)
+			}
+
+			fmt.Printf("Updated branch '%s'\n", localBranch)
+			return nil
+		}
+
+		checkoutCmd := exec.Command("git", "checkout", "-b", localBranch, "FETCH_HEAD")
+		checkoutCmd.Stdout = os.Stdout
+		checkoutCmd.Stderr = os.Stderr
+		if err := checkoutCmd.Run(); err != nil {
+			return fmt.Errorf("checking out: %w", err)
+		}
+		fmt.Printf("Switched to branch '%s'\n", localBranch)
+		return nil
+	},
+}
+
+func branchExists(name string) bool {
+	err := exec.Command("git", "rev-parse", "--verify", name).Run()
+	return err == nil
+}
+
+func init() {
+	prCmd.AddCommand(prCheckoutCmd)
+
+	prCheckoutCmd.Flags().StringP("branch", "b", "", "Local branch name (default: pr-<id>)")
+	prCheckoutCmd.Flags().Bool("detach", false, "Checkout in detached HEAD state")
+	prCheckoutCmd.Flags().BoolP("force", "f", false, "Force overwrite local branch")
+}

--- a/cmd/pr_create.go
+++ b/cmd/pr_create.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var prCreateCmd = &cobra.Command{
+	Use:   "create [project/repo]",
+	Short: "Create a pull request",
+	Long: `Create a new pull request from the current branch.
+
+If no title is provided and --fill is used, the title will be derived from
+the first commit message on the branch.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		var arg string
+		if len(args) > 0 {
+			arg = args[0]
+		}
+
+		project, repo, err := parseRepoArg(arg)
+		if err != nil {
+			return err
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		title, _ := cmd.Flags().GetString("title")
+		body, _ := cmd.Flags().GetString("body")
+		base, _ := cmd.Flags().GetString("base")
+		head, _ := cmd.Flags().GetString("head")
+		reviewers, _ := cmd.Flags().GetStringSlice("reviewer")
+		fill, _ := cmd.Flags().GetBool("fill")
+		web, _ := cmd.Flags().GetBool("web")
+
+		if head == "" {
+			head, err = getCurrentGitBranch()
+			if err != nil {
+				return fmt.Errorf("could not determine current branch: %w", err)
+			}
+		}
+
+		if base == "" {
+			base, err = client.GetDefaultBranch(ctx, project, repo)
+			if err != nil {
+				base = "main"
+			}
+		}
+
+		if fill && title == "" {
+			title, body = fillFromCommits(base, head)
+		}
+
+		if title == "" {
+			return fmt.Errorf("--title is required (or use --fill to derive from commits)")
+		}
+
+		pr, err := client.CreatePullRequest(ctx, project, repo, title, body, head, base, reviewers)
+		if err != nil {
+			return fmt.Errorf("creating pull request: %w", err)
+		}
+
+		prURL := getPRURL(client.Client.BaseURL, project, repo, pr.ID)
+
+		if web {
+			if err := openBrowser(prURL); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not open browser: %v\n", err)
+			}
+		}
+
+		fmt.Printf("Created PR #%d: %s\n", pr.ID, pr.Title)
+		fmt.Printf("%s -> %s\n", pr.FromRef.DisplayID, pr.ToRef.DisplayID)
+		fmt.Printf("%s\n", prURL)
+
+		return nil
+	},
+}
+
+func getCurrentGitBranch() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func fillFromCommits(base, head string) (title, body string) {
+	out, err := exec.Command("git", "log", "--format=%s", "--reverse", base+".."+head).Output()
+	if err != nil {
+		return "", ""
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 0 {
+		return "", ""
+	}
+
+	title = lines[0]
+	if len(lines) > 1 {
+		body = strings.Join(lines[1:], "\n")
+	}
+
+	return title, body
+}
+
+func getPRURL(baseURL, project, repo string, prID int) string {
+	return fmt.Sprintf("%s/projects/%s/repos/%s/pull-requests/%d", baseURL, project, repo, prID)
+}
+
+func init() {
+	prCmd.AddCommand(prCreateCmd)
+
+	prCreateCmd.Flags().StringP("title", "t", "", "Title for the pull request")
+	prCreateCmd.Flags().StringP("body", "b", "", "Body/description for the pull request")
+	prCreateCmd.Flags().StringP("base", "B", "", "Base branch (default: repo default branch)")
+	prCreateCmd.Flags().StringP("head", "H", "", "Head branch (default: current branch)")
+	prCreateCmd.Flags().StringSliceP("reviewer", "r", nil, "Request review from these users")
+	prCreateCmd.Flags().Bool("fill", false, "Use commit messages to fill title and body")
+	prCreateCmd.Flags().BoolP("web", "w", false, "Open the PR in browser after creation")
+}

--- a/cmd/pr_edit.go
+++ b/cmd/pr_edit.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/lroolle/atlas-cli/api"
+	"github.com/spf13/cobra"
+)
+
+var prEditCmd = &cobra.Command{
+	Use:   "edit [project/repo] <pr-id>",
+	Short: "Edit pull request properties",
+	Long: `Edit a pull request's title, description, base branch, or reviewers.
+
+Examples:
+  atl pr edit 123 --title "New title"
+  atl pr edit 123 --add-reviewer alice --add-reviewer bob
+  atl pr edit 123 --remove-reviewer charlie`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		pr, err := client.GetPullRequest(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("fetching PR: %w", err)
+		}
+
+		title, _ := cmd.Flags().GetString("title")
+		body, _ := cmd.Flags().GetString("body")
+		base, _ := cmd.Flags().GetString("base")
+		addReviewers, _ := cmd.Flags().GetStringSlice("add-reviewer")
+		removeReviewers, _ := cmd.Flags().GetStringSlice("remove-reviewer")
+
+		hasUpdates := title != "" || body != "" || base != ""
+
+		for _, r := range removeReviewers {
+			if err := client.RemoveReviewer(ctx, project, repo, prID, r); err != nil {
+				fmt.Printf("Warning: could not remove reviewer %s: %v\n", r, err)
+			} else {
+				fmt.Printf("Removed reviewer: %s\n", r)
+			}
+		}
+
+		for _, r := range addReviewers {
+			if err := client.AddReviewer(ctx, project, repo, prID, r); err != nil {
+				fmt.Printf("Warning: could not add reviewer %s: %v\n", r, err)
+			} else {
+				fmt.Printf("Added reviewer: %s\n", r)
+			}
+		}
+
+		if hasUpdates {
+			opts := api.UpdatePROptions{
+				Title:       title,
+				Description: body,
+				ToRef:       base,
+				Version:     pr.Version,
+			}
+
+			updatedPR, err := client.UpdatePullRequest(ctx, project, repo, prID, opts)
+			if err != nil {
+				return fmt.Errorf("updating PR: %w", err)
+			}
+
+			fmt.Printf("Updated PR #%d: %s\n", prID, updatedPR.Title)
+		} else if len(addReviewers) == 0 && len(removeReviewers) == 0 {
+			return fmt.Errorf("no changes specified")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	prCmd.AddCommand(prEditCmd)
+
+	prEditCmd.Flags().StringP("title", "t", "", "New title")
+	prEditCmd.Flags().StringP("body", "b", "", "New description")
+	prEditCmd.Flags().StringP("base", "B", "", "Change target branch")
+	prEditCmd.Flags().StringSlice("add-reviewer", nil, "Add reviewer (can be repeated)")
+	prEditCmd.Flags().StringSlice("remove-reviewer", nil, "Remove reviewer (can be repeated)")
+}

--- a/cmd/pr_info.go
+++ b/cmd/pr_info.go
@@ -1,0 +1,320 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/lroolle/atlas-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+var prCommitsCmd = &cobra.Command{
+	Use:   "commits [project/repo] <pr-id>",
+	Short: "List commits in a pull request",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		limit, _ := cmd.Flags().GetInt("limit")
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+
+		commits, err := client.GetPullRequestCommits(ctx, project, repo, prID, limit)
+		if err != nil {
+			return fmt.Errorf("fetching commits: %w", err)
+		}
+
+		if jsonOutput {
+			return json.NewEncoder(os.Stdout).Encode(commits)
+		}
+
+		if len(commits) == 0 {
+			fmt.Println("No commits found")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "SHA\tMESSAGE\tAUTHOR\tDATE")
+
+		for _, c := range commits {
+			date := time.Unix(c.AuthorTimestamp/1000, 0).Format("2006-01-02")
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+				c.DisplayID,
+				cmdutil.Truncate(firstLine(c.Message), cmdutil.TitleTruncateNormal),
+				c.Author.Name,
+				date,
+			)
+		}
+
+		return w.Flush()
+	},
+}
+
+var prFilesCmd = &cobra.Command{
+	Use:     "files [project/repo] <pr-id>",
+	Short:   "List files changed in a pull request",
+	Aliases: []string{"changes"},
+	Args:    cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		limit, _ := cmd.Flags().GetInt("limit")
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+
+		changes, err := client.GetPullRequestChanges(ctx, project, repo, prID, limit)
+		if err != nil {
+			return fmt.Errorf("fetching changes: %w", err)
+		}
+
+		if jsonOutput {
+			return json.NewEncoder(os.Stdout).Encode(changes)
+		}
+
+		if len(changes) == 0 {
+			fmt.Println("No files changed")
+			return nil
+		}
+
+		for _, c := range changes {
+			status := changeTypeSymbol(c.Type)
+			path := c.Path.ToString
+			if c.SrcPath != nil && c.SrcPath.ToString != path {
+				path = fmt.Sprintf("%s -> %s", c.SrcPath.ToString, path)
+			}
+			fmt.Printf("%s %s\n", status, path)
+		}
+
+		return nil
+	},
+}
+
+var prActivityCmd = &cobra.Command{
+	Use:   "activity [project/repo] <pr-id>",
+	Short: "Show activity on a pull request",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		limit, _ := cmd.Flags().GetInt("limit")
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+
+		activities, err := client.GetPullRequestActivity(ctx, project, repo, prID, limit)
+		if err != nil {
+			return fmt.Errorf("fetching activity: %w", err)
+		}
+
+		if jsonOutput {
+			return json.NewEncoder(os.Stdout).Encode(activities)
+		}
+
+		if len(activities) == 0 {
+			fmt.Println("No activity found")
+			return nil
+		}
+
+		for _, a := range activities {
+			date := time.Unix(a.CreatedDate/1000, 0).Format("2006-01-02 15:04")
+			action := a.Action
+			detail := ""
+			if a.Comment != nil {
+				detail = cmdutil.Truncate(a.Comment.Text, 60)
+			}
+			fmt.Printf("%s  %s  %s  %s\n", date, a.User.Name, action, detail)
+		}
+
+		return nil
+	},
+}
+
+var prCanMergeCmd = &cobra.Command{
+	Use:   "can-merge [project/repo] <pr-id>",
+	Short: "Check if a pull request can be merged",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+
+		result, err := client.CanMerge(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("checking merge status: %w", err)
+		}
+
+		if jsonOutput {
+			return json.NewEncoder(os.Stdout).Encode(result)
+		}
+
+		if result.CanMerge {
+			fmt.Printf("✓ PR #%d can be merged\n", prID)
+		} else {
+			fmt.Printf("✗ PR #%d cannot be merged\n", prID)
+			if result.Conflicted {
+				fmt.Println("  Reason: conflicts detected")
+			}
+			for _, v := range result.Vetoes {
+				fmt.Printf("  Veto: %s\n", v.SummaryMessage)
+			}
+		}
+
+		return nil
+	},
+}
+
+func changeTypeSymbol(t string) string {
+	switch t {
+	case "ADD":
+		return "A"
+	case "MODIFY":
+		return "M"
+	case "DELETE":
+		return "D"
+	case "MOVE":
+		return "R"
+	case "COPY":
+		return "C"
+	default:
+		return "?"
+	}
+}
+
+func firstLine(s string) string {
+	for i, c := range s {
+		if c == '\n' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+func init() {
+	prCmd.AddCommand(prCommitsCmd)
+	prCmd.AddCommand(prFilesCmd)
+	prCmd.AddCommand(prActivityCmd)
+	prCmd.AddCommand(prCanMergeCmd)
+
+	prCommitsCmd.Flags().Int("limit", cmdutil.DefaultLimit, "Maximum number of commits")
+	prCommitsCmd.Flags().Bool("json", false, "Output as JSON")
+
+	prFilesCmd.Flags().Int("limit", 100, "Maximum number of files")
+	prFilesCmd.Flags().Bool("json", false, "Output as JSON")
+
+	prActivityCmd.Flags().Int("limit", cmdutil.DefaultLimit, "Maximum number of activities")
+	prActivityCmd.Flags().Bool("json", false, "Output as JSON")
+
+	prCanMergeCmd.Flags().Bool("json", false, "Output as JSON")
+}

--- a/cmd/pr_lifecycle.go
+++ b/cmd/pr_lifecycle.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var prDeclineCmd = &cobra.Command{
+	Use:     "decline [project/repo] <pr-id>",
+	Short:   "Decline a pull request",
+	Aliases: []string{"close"},
+	Args:    cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		pr, err := client.GetPullRequest(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("fetching PR: %w", err)
+		}
+
+		if pr.State != "OPEN" {
+			return fmt.Errorf("PR #%d is not open (state: %s)", prID, pr.State)
+		}
+
+		comment, _ := cmd.Flags().GetString("comment")
+		if comment != "" {
+			if _, err := client.AddPullRequestComment(ctx, project, repo, prID, comment); err != nil {
+				return fmt.Errorf("adding comment: %w", err)
+			}
+		}
+
+		if err := client.DeclinePullRequest(ctx, project, repo, prID, pr.Version); err != nil {
+			return fmt.Errorf("declining PR: %w", err)
+		}
+
+		fmt.Printf("✗ Declined PR #%d: %s\n", prID, pr.Title)
+		return nil
+	},
+}
+
+var prReopenCmd = &cobra.Command{
+	Use:   "reopen [project/repo] <pr-id>",
+	Short: "Reopen a declined pull request",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		pr, err := client.GetPullRequest(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("fetching PR: %w", err)
+		}
+
+		if pr.State != "DECLINED" {
+			return fmt.Errorf("PR #%d is not declined (state: %s)", prID, pr.State)
+		}
+
+		if err := client.ReopenPullRequest(ctx, project, repo, prID, pr.Version); err != nil {
+			return fmt.Errorf("reopening PR: %w", err)
+		}
+
+		fmt.Printf("✓ Reopened PR #%d: %s\n", prID, pr.Title)
+		return nil
+	},
+}
+
+var prRebaseCmd = &cobra.Command{
+	Use:   "rebase [project/repo] <pr-id>",
+	Short: "Rebase a pull request (server-side)",
+	Long:  `Rebase the pull request's source branch on top of the target branch using server-side rebase.`,
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		pr, err := client.GetPullRequest(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("fetching PR: %w", err)
+		}
+
+		if pr.State != "OPEN" {
+			return fmt.Errorf("PR #%d is not open (state: %s)", prID, pr.State)
+		}
+
+		if err := client.RebasePullRequest(ctx, project, repo, prID, pr.Version); err != nil {
+			return fmt.Errorf("rebasing PR: %w", err)
+		}
+
+		fmt.Printf("✓ Rebased PR #%d: %s\n", prID, pr.Title)
+		return nil
+	},
+}
+
+func init() {
+	prCmd.AddCommand(prDeclineCmd)
+	prCmd.AddCommand(prReopenCmd)
+	prCmd.AddCommand(prRebaseCmd)
+
+	prDeclineCmd.Flags().StringP("comment", "c", "", "Add a comment when declining")
+}

--- a/cmd/pr_review.go
+++ b/cmd/pr_review.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var prReviewCmd = &cobra.Command{
+	Use:   "review [project/repo] <pr-id>",
+	Short: "Add a review to a pull request",
+	Long: `Add a review to a pull request with optional comment.
+
+Review actions:
+  --approve (-a)           Approve the pull request
+  --request-changes (-r)   Request changes (sets NEEDS_WORK status)
+  --comment (-c)           Add a comment without changing approval status
+
+If no action is specified, --comment is assumed when --body is provided.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		approve, _ := cmd.Flags().GetBool("approve")
+		requestChanges, _ := cmd.Flags().GetBool("request-changes")
+		comment, _ := cmd.Flags().GetBool("comment")
+		body, _ := cmd.Flags().GetString("body")
+
+		actionCount := 0
+		if approve {
+			actionCount++
+		}
+		if requestChanges {
+			actionCount++
+		}
+		if comment {
+			actionCount++
+		}
+
+		if actionCount > 1 {
+			return fmt.Errorf("only one of --approve, --request-changes, or --comment can be specified")
+		}
+
+		if actionCount == 0 && body != "" {
+			comment = true
+		}
+
+		if actionCount == 0 && body == "" {
+			return fmt.Errorf("specify --approve, --request-changes, --comment, or provide --body")
+		}
+		if comment && body == "" {
+			return fmt.Errorf("--comment requires --body")
+		}
+
+		pr, err := client.GetPullRequest(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("fetching PR: %w", err)
+		}
+
+		if approve {
+			if err := client.ApprovePullRequest(ctx, project, repo, prID); err != nil {
+				return fmt.Errorf("approving PR: %w", err)
+			}
+			fmt.Printf("✓ Approved PR #%d: %s\n", prID, pr.Title)
+		}
+
+		if requestChanges {
+			if err := client.SetReviewerStatus(ctx, project, repo, prID, "NEEDS_WORK"); err != nil {
+				return fmt.Errorf("requesting changes: %w", err)
+			}
+			fmt.Printf("✗ Requested changes on PR #%d: %s\n", prID, pr.Title)
+		}
+
+		if body != "" {
+			if _, err := client.AddPullRequestComment(ctx, project, repo, prID, body); err != nil {
+				return fmt.Errorf("adding comment: %w", err)
+			}
+			if comment && !approve && !requestChanges {
+				fmt.Printf("Commented on PR #%d: %s\n", prID, pr.Title)
+			}
+		}
+
+		return nil
+	},
+}
+
+var prApproveCmd = &cobra.Command{
+	Use:   "approve [project/repo] <pr-id>",
+	Short: "Approve a pull request",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		pr, err := client.GetPullRequest(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("fetching PR: %w", err)
+		}
+
+		if err := client.ApprovePullRequest(ctx, project, repo, prID); err != nil {
+			return fmt.Errorf("approving PR: %w", err)
+		}
+
+		fmt.Printf("✓ Approved PR #%d: %s\n", prID, pr.Title)
+		return nil
+	},
+}
+
+var prUnapproveCmd = &cobra.Command{
+	Use:   "unapprove [project/repo] <pr-id>",
+	Short: "Remove approval from a pull request",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		var project, repo string
+		var prIDStr string
+
+		if len(args) == 2 {
+			var err error
+			project, repo, err = parseRepoArg(args[0])
+			if err != nil {
+				return err
+			}
+			prIDStr = args[1]
+		} else {
+			var err error
+			project, repo, err = parseRepoArg("")
+			if err != nil {
+				return fmt.Errorf("PR ID required: %w", err)
+			}
+			prIDStr = args[0]
+		}
+
+		prID, err := strconv.Atoi(prIDStr)
+		if err != nil {
+			return fmt.Errorf("invalid PR ID: %v", err)
+		}
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		pr, err := client.GetPullRequest(ctx, project, repo, prID)
+		if err != nil {
+			return fmt.Errorf("fetching PR: %w", err)
+		}
+
+		if err := client.UnapprovePullRequest(ctx, project, repo, prID); err != nil {
+			return fmt.Errorf("removing approval: %w", err)
+		}
+
+		fmt.Printf("Removed approval from PR #%d: %s\n", prID, pr.Title)
+		return nil
+	},
+}
+
+func init() {
+	prCmd.AddCommand(prReviewCmd)
+	prCmd.AddCommand(prApproveCmd)
+	prCmd.AddCommand(prUnapproveCmd)
+
+	prReviewCmd.Flags().BoolP("approve", "a", false, "Approve the pull request")
+	prReviewCmd.Flags().BoolP("request-changes", "r", false, "Request changes")
+	prReviewCmd.Flags().BoolP("comment", "c", false, "Add comment only")
+	prReviewCmd.Flags().StringP("body", "b", "", "Comment text")
+}

--- a/cmd/pr_status.go
+++ b/cmd/pr_status.go
@@ -24,7 +24,7 @@ var prStatusCmd = &cobra.Command{
 		project, repo, err := parseRepoArg("")
 		if err != nil {
 			fmt.Printf("No default repository configured: %v\n", err)
-			fmt.Println("Use 'atlas pr list PROJECT/REPO' instead.")
+			fmt.Println("Use 'atl pr list PROJECT/REPO' instead.")
 			return nil
 		}
 

--- a/docs/devlog/2024-12-18-pr-commands.org
+++ b/docs/devlog/2024-12-18-pr-commands.org
@@ -1,0 +1,92 @@
+* [2024-12-18] Dev Log: Bitbucket PR Command Suite Implementation :FEATURE:
+
+** Context
+atlas-cli: Atlassian CLI tool for Bitbucket/Jira operations in Go
+
+** Why
+Add comprehensive PR workflow support - 13 new subcommands to enable scriptable Bitbucket PR management via CLI
+
+** What
+- Expanded =atl pr= from 6 to 19 subcommands with JSON output and browser integration
+- Added 15 API methods to api/bitbucket.go for PR lifecycle operations
+- Fixed 7 critical bugs post-implementation (unsafe merge, lying flags, resource leaks)
+- Created 6 new command files + cross-platform browser launcher
+
+** How
+*** New Commands
+| Command          | Flags                                      | Purpose                               |
+|------------------+--------------------------------------------+---------------------------------------|
+| create           | --title --body --fill --reviewer --web     | Create PR with auto-fill from commits |
+| checkout (co)    | --branch --detach --force                  | Safe checkout to new branch           |
+| review           | --approve --request-changes --comment --body | Review workflow                     |
+| approve          |                                            | Approve PR                            |
+| unapprove        |                                            | Remove approval                       |
+| decline (close)  | --comment                                  | Decline/close PR                      |
+| reopen           |                                            | Reopen declined PR                    |
+| edit             | --title --body --base --add/remove-reviewer | Update PR metadata                   |
+| rebase           |                                            | Server-side rebase                    |
+| commits          | --limit --json                             | List PR commits                       |
+| files (changes)  | --limit --json                             | Show PR file changes                  |
+| activity         | --limit --json                             | Show PR activity stream               |
+| can-merge        | --json                                     | Check merge preconditions             |
+
+*** Files Created
+#+BEGIN_SRC
+cmd/pr_create.go       # PR creation with --fill from git log
+cmd/pr_checkout.go     # Safe checkout to new branch
+cmd/pr_review.go       # Review workflow (approve/unapprove/review)
+cmd/pr_lifecycle.go    # State transitions (decline/reopen/rebase)
+cmd/pr_edit.go         # Metadata updates (title/body/reviewers)
+cmd/pr_info.go         # Inspection (commits/files/activity/can-merge)
+cmd/browser.go         # Cross-platform browser launcher
+#+END_SRC
+
+*** API Methods Added (api/bitbucket.go)
+#+BEGIN_SRC go
+// Lifecycle
+ApprovePullRequest, UnapprovePullRequest
+SetReviewerStatus, DeclinePullRequest, ReopenPullRequest
+
+// Metadata
+UpdatePullRequest, AddReviewer, RemoveReviewer
+
+// Inspection
+GetPullRequestCommits, GetPullRequestChanges
+GetPullRequestActivity, CanMerge
+
+// Operations
+RebasePullRequest, DeleteBranch, GetDefaultBranch
+
+// Client primitives (api/client.go)
+doRequestWithAccept, DeleteWithBody
+#+END_SRC
+
+*** Bugs Fixed
+| Bug | Fix |
+|-----+-----|
+| --delete-branch flag declared but not implemented | Wire up DeleteBranch API call |
+| --base/--head flags declared but not used | Implement branch filtering with normalization |
+| pr checkout merging into current branch | Always create new branch, fail on diverge |
+| --web and --json allowed together | Make mutually exclusive |
+| GetPullRequestDiff response body leak | Close body before error check, use text/plain Accept |
+| pr review --comment allowed without --body | Require --body when --comment specified |
+| openBrowser only worked on macOS | Add linux (xdg-open) and windows support |
+
+** Lessons Learned
+1. *No Lying Flags* - Declaring a flag without implementing it is worse than not having it
+2. *Git Ops Must Be Safe* - Never auto-merge into current branch
+3. *Exclusive Output Modes* - --web and --json don't mix
+4. *HTTP Hygiene* - Close bodies on error paths, set correct Accept header
+5. *Flag Validation* - Enforce required combinations (--comment needs --body)
+6. *Cross-Platform* - Don't assume macOS =open= command exists
+7. *Normalize Inputs* - Handle refs/heads/ prefix in branch names
+
+** Result
+19 PR subcommands operational with --json for scripting and --web for browser integration.
+All 7 post-implementation bugs resolved.
+
+** Next Steps
+- [ ] Add pagination for commits/files/activity
+- [ ] Add unit tests for API methods
+- [ ] Consider pr watch/unwatch (low priority)
+- [ ] Consider pr auto-merge settings (low priority)


### PR DESCRIPTION
## Summary
- Add 13 new PR subcommands (19 total under `atl pr`)
- Add 15+ API methods to api/bitbucket.go
- Implement gh-cli patterns: --json, --web, --fill

## New Commands
- create, checkout (co), review, approve, unapprove
- decline (close), reopen, edit, rebase
- commits, files (changes), activity, can-merge

## Post-implementation fixes
- Fixed lying flags (--delete-branch, --base, --head)
- Safe git ops in pr checkout
- --web/--json mutual exclusivity
- HTTP response hygiene
- Cross-platform browser opening

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./...
- [x] Manual verification of commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)