### PR TITLE
feat(jira): transition engine, issue create, subtask support [v0.2.0]

### DIFF
--- a/api/jira.go
+++ b/api/jira.go
@@ -268,6 +268,46 @@ func (c *JiraClient) GetRepositoryInfo(ctx context.Context, issueKey string) (*D
 	return &devInfo, nil
 }
 
+type CreatedIssue struct {
+	ID   string `json:"id"`
+	Key  string `json:"key"`
+	Self string `json:"self"`
+}
+
+func (c *JiraClient) CreateIssue(ctx context.Context, fields map[string]interface{}) (*CreatedIssue, error) {
+	body := map[string]interface{}{
+		"fields": fields,
+	}
+
+	var created CreatedIssue
+	err := c.Post(ctx, "/rest/api/2/issue", body, &created)
+	if err != nil {
+		return nil, err
+	}
+
+	return &created, nil
+}
+
+type JiraField struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Custom bool   `json:"custom"`
+	Schema struct {
+		Type   string `json:"type"`
+		Custom string `json:"custom"`
+	} `json:"schema"`
+}
+
+func (c *JiraClient) GetFields(ctx context.Context) ([]JiraField, error) {
+	var fields []JiraField
+	err := c.Get(ctx, "/rest/api/2/field", nil, &fields)
+	if err != nil {
+		return nil, err
+	}
+
+	return fields, nil
+}
+
 func (c *JiraClient) UpdateIssue(ctx context.Context, issueKey string, fields map[string]interface{}) error {
 	path := fmt.Sprintf("/rest/api/2/issue/%s", issueKey)
 

--- a/api/jira.go
+++ b/api/jira.go
@@ -154,13 +154,16 @@ func (c *JiraClient) GetTransitions(ctx context.Context, issueKey string) ([]Tra
 	return response.Transitions, nil
 }
 
-func (c *JiraClient) TransitionIssue(ctx context.Context, issueKey string, transitionID string) error {
+func (c *JiraClient) TransitionIssue(ctx context.Context, issueKey string, transitionID string, fields map[string]interface{}) error {
 	path := fmt.Sprintf("/rest/api/2/issue/%s/transitions", issueKey)
 
 	body := map[string]interface{}{
 		"transition": map[string]string{
 			"id": transitionID,
 		},
+	}
+	if len(fields) > 0 {
+		body["fields"] = fields
 	}
 
 	return c.Post(ctx, path, body, nil)

--- a/api/jira.go
+++ b/api/jira.go
@@ -99,9 +99,37 @@ type LinkType struct {
 }
 
 type Transition struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	To   Status `json:"to"`
+	ID     string                     `json:"id"`
+	Name   string                     `json:"name"`
+	To     Status                     `json:"to"`
+	Fields map[string]TransitionField `json:"fields,omitempty"`
+}
+
+type TransitionField struct {
+	Required      bool             `json:"required"`
+	Name          string           `json:"name"`
+	Schema        TransitionSchema `json:"schema"`
+	AllowedValues []AllowedValue   `json:"allowedValues,omitempty"`
+}
+
+type TransitionSchema struct {
+	Type  string `json:"type"`
+	Items string `json:"items,omitempty"`
+}
+
+type AllowedValue struct {
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// Display returns the human-facing label of an allowed value: option fields
+// use "value", most other types (resolution, version, ...) use "name".
+func (v AllowedValue) Display() string {
+	if v.Value != "" {
+		return v.Value
+	}
+	return v.Name
 }
 
 type SearchResult struct {
@@ -142,11 +170,14 @@ func (c *JiraClient) GetIssue(ctx context.Context, issueKey string) (*Issue, err
 func (c *JiraClient) GetTransitions(ctx context.Context, issueKey string) ([]Transition, error) {
 	path := fmt.Sprintf("/rest/api/2/issue/%s/transitions", issueKey)
 
+	params := url.Values{}
+	params.Set("expand", "transitions.fields")
+
 	var response struct {
 		Transitions []Transition `json:"transitions"`
 	}
 
-	err := c.Get(ctx, path, nil, &response)
+	err := c.Get(ctx, path, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -154,9 +185,16 @@ func (c *JiraClient) GetTransitions(ctx context.Context, issueKey string) ([]Tra
 	return response.Transitions, nil
 }
 
-func (c *JiraClient) TransitionIssue(ctx context.Context, issueKey string, transitionID string, fields map[string]interface{}) error {
-	path := fmt.Sprintf("/rest/api/2/issue/%s/transitions", issueKey)
+// TransitionUpdate carries operations applied via the transition's
+// "update" block (as opposed to plain field values).
+type TransitionUpdate struct {
+	Comment   string
+	TimeSpent string // Jira duration, e.g. "2h", "30m", "1d 4h"
+}
 
+// TransitionBody builds the request body POSTed to the transitions
+// endpoint; exposed so callers can show it verbatim (e.g. --dry-run).
+func TransitionBody(transitionID string, fields map[string]interface{}, update TransitionUpdate) map[string]interface{} {
 	body := map[string]interface{}{
 		"transition": map[string]string{
 			"id": transitionID,
@@ -166,7 +204,27 @@ func (c *JiraClient) TransitionIssue(ctx context.Context, issueKey string, trans
 		body["fields"] = fields
 	}
 
-	return c.Post(ctx, path, body, nil)
+	upd := make(map[string]interface{})
+	if update.Comment != "" {
+		upd["comment"] = []map[string]interface{}{
+			{"add": map[string]string{"body": update.Comment}},
+		}
+	}
+	if update.TimeSpent != "" {
+		upd["worklog"] = []map[string]interface{}{
+			{"add": map[string]string{"timeSpent": update.TimeSpent}},
+		}
+	}
+	if len(upd) > 0 {
+		body["update"] = upd
+	}
+
+	return body
+}
+
+func (c *JiraClient) TransitionIssue(ctx context.Context, issueKey string, transitionID string, fields map[string]interface{}, update TransitionUpdate) error {
+	path := fmt.Sprintf("/rest/api/2/issue/%s/transitions", issueKey)
+	return c.Post(ctx, path, TransitionBody(transitionID, fields, update), nil)
 }
 
 func (c *JiraClient) AddComment(ctx context.Context, issueKey string, comment string) error {

--- a/api/jira_test.go
+++ b/api/jira_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestJiraClient(server *httptest.Server) *JiraClient {
+	client := NewJiraClient(server.URL, "tester", "token")
+	client.HTTPClient = server.Client()
+	return client
+}
+
+func TestCreateIssue(t *testing.T) {
+	var gotPath, gotMethod, gotAuth string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"100001","key":"GAUSS-1234","self":"https://jira.example.com/rest/api/2/issue/100001"}`))
+	}))
+	defer server.Close()
+
+	client := newTestJiraClient(server)
+
+	fields := map[string]interface{}{
+		"project":   map[string]string{"key": "GAUSS"},
+		"issuetype": map[string]string{"name": "Story"},
+		"summary":   "test story",
+	}
+
+	created, err := client.CreateIssue(context.Background(), fields)
+	if err != nil {
+		t.Fatalf("CreateIssue returned error: %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/rest/api/2/issue" {
+		t.Errorf("path = %q, want /rest/api/2/issue", gotPath)
+	}
+	if gotAuth != "Bearer token" {
+		t.Errorf("auth = %q, want Bearer token", gotAuth)
+	}
+	if created.Key != "GAUSS-1234" {
+		t.Errorf("key = %q, want GAUSS-1234", created.Key)
+	}
+	if created.ID != "100001" {
+		t.Errorf("id = %q, want 100001", created.ID)
+	}
+
+	sentFields, ok := gotBody["fields"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("request body missing fields object: %v", gotBody)
+	}
+	if sentFields["summary"] != "test story" {
+		t.Errorf("sent summary = %v, want test story", sentFields["summary"])
+	}
+}
+
+func TestCreateIssueServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errorMessages":["Issue type is required"],"errors":{}}`))
+	}))
+	defer server.Close()
+
+	client := newTestJiraClient(server)
+
+	_, err := client.CreateIssue(context.Background(), map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var unexpected *ErrUnexpectedResponse
+	if !errors.As(err, &unexpected) {
+		t.Fatalf("error type = %T, want *ErrUnexpectedResponse", err)
+	}
+	if unexpected.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", unexpected.StatusCode)
+	}
+}
+
+func TestGetFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/2/field" {
+			t.Errorf("path = %q, want /rest/api/2/field", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`[
+			{"id":"summary","name":"Summary","custom":false,"schema":{"type":"string"}},
+			{"id":"customfield_10501","name":"Epic Link","custom":true,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link"}},
+			{"id":"customfield_10401","name":"Sprint","custom":true,"schema":{"type":"array","custom":"com.pyxis.greenhopper.jira:gh-sprint"}}
+		]`))
+	}))
+	defer server.Close()
+
+	client := newTestJiraClient(server)
+
+	fields, err := client.GetFields(context.Background())
+	if err != nil {
+		t.Fatalf("GetFields returned error: %v", err)
+	}
+	if len(fields) != 3 {
+		t.Fatalf("len(fields) = %d, want 3", len(fields))
+	}
+	if fields[1].ID != "customfield_10501" || fields[1].Schema.Custom != "com.pyxis.greenhopper.jira:gh-epic-link" {
+		t.Errorf("epic field parsed wrong: %+v", fields[1])
+	}
+}

--- a/api/jira_test.go
+++ b/api/jira_test.go
@@ -27,14 +27,14 @@ func TestCreateIssue(t *testing.T) {
 			t.Fatalf("decoding request body: %v", err)
 		}
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"id":"100001","key":"GAUSS-1234","self":"https://jira.example.com/rest/api/2/issue/100001"}`))
+		_, _ = w.Write([]byte(`{"id":"100001","key":"MYPROJ-1234","self":"https://jira.example.com/rest/api/2/issue/100001"}`))
 	}))
 	defer server.Close()
 
 	client := newTestJiraClient(server)
 
 	fields := map[string]interface{}{
-		"project":   map[string]string{"key": "GAUSS"},
+		"project":   map[string]string{"key": "MYPROJ"},
 		"issuetype": map[string]string{"name": "Story"},
 		"summary":   "test story",
 	}
@@ -53,8 +53,8 @@ func TestCreateIssue(t *testing.T) {
 	if gotAuth != "Bearer token" {
 		t.Errorf("auth = %q, want Bearer token", gotAuth)
 	}
-	if created.Key != "GAUSS-1234" {
-		t.Errorf("key = %q, want GAUSS-1234", created.Key)
+	if created.Key != "MYPROJ-1234" {
+		t.Errorf("key = %q, want MYPROJ-1234", created.Key)
 	}
 	if created.ID != "100001" {
 		t.Errorf("id = %q, want 100001", created.ID)

--- a/cmd/jira.go
+++ b/cmd/jira.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -330,7 +331,41 @@ var issueTransitionCmd = &cobra.Command{
 			return fmt.Errorf("transition '%s' not found", args[1])
 		}
 
-		err = client.TransitionIssue(ctx, issueKey, targetTransition.ID)
+		fields := make(map[string]interface{})
+
+		if r, _ := cmd.Flags().GetString("resolution"); r != "" {
+			fields["resolution"] = map[string]string{"name": r}
+		}
+
+		if fv, _ := cmd.Flags().GetStringSlice("fix-version"); len(fv) > 0 {
+			versions := make([]map[string]string, len(fv))
+			for i, v := range fv {
+				versions[i] = map[string]string{"name": v}
+			}
+			fields["fixVersions"] = versions
+		}
+
+		if rawFields, _ := cmd.Flags().GetStringArray("field"); len(rawFields) > 0 {
+			for _, f := range rawFields {
+				parts := strings.SplitN(f, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("invalid --field format %q, expected key=value", f)
+				}
+				val := parts[1]
+				if strings.HasPrefix(val, "[") || strings.HasPrefix(val, "{") {
+					var parsed interface{}
+					if err := json.Unmarshal([]byte(val), &parsed); err == nil {
+						fields[parts[0]] = parsed
+					} else {
+						fields[parts[0]] = val
+					}
+				} else {
+					fields[parts[0]] = val
+				}
+			}
+		}
+
+		err = client.TransitionIssue(ctx, issueKey, targetTransition.ID, fields)
 		if err != nil {
 			return err
 		}
@@ -457,6 +492,9 @@ func init() {
 	issueCmd.AddCommand(issueListCmd)
 	issueCmd.AddCommand(issueViewCmd)
 	issueCmd.AddCommand(issueTransitionCmd)
+	issueTransitionCmd.Flags().StringP("resolution", "R", "", "Resolution name (e.g. Done, Won't Fix)")
+	issueTransitionCmd.Flags().StringSlice("fix-version", nil, "Fix version(s) to set")
+	issueTransitionCmd.Flags().StringArray("field", nil, "Additional fields as key=value (repeatable)")
 	issueCmd.AddCommand(issueCommentCmd)
 	issueCmd.AddCommand(issueCommentsCmd)
 	issueCmd.AddCommand(issuePrsCmd)

--- a/cmd/jira.go
+++ b/cmd/jira.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -26,7 +25,7 @@ var issueListCmd = &cobra.Command{
 	Long: `List JIRA issues with various filters.
 
 You can combine flags to create complex queries:
-  atl issue list -t Bug -s Open -e GAUSS-18421
+  atl issue list -t Bug -s Open -e MYPROJ-100
   atl issue list -a me -y High --label backend
 
 Use ~ prefix for negation (quote to prevent shell expansion):
@@ -34,7 +33,7 @@ Use ~ prefix for negation (quote to prevent shell expansion):
   atl issue list --label '~wontfix'    # exclude label`,
 	Example: `  atl issue list
   atl issue list -t Bug -s Open
-  atl issue list -e GAUSS-18421 -a me
+  atl issue list -e MYPROJ-100 -a me
   atl issue list -e 18421              # auto-prefix with default project
   atl issue list -q "created >= -7d"
   atl issue list --order-by updated --reverse`,
@@ -292,89 +291,6 @@ var issueViewCmd = &cobra.Command{
 	},
 }
 
-var issueTransitionCmd = &cobra.Command{
-	Use:   "transition [issue-key] [transition-name]",
-	Short: "Transition a JIRA issue to a new status",
-	Args:  cobra.RangeArgs(1, 2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-
-		client, err := api.GetJiraClient()
-		cmdutil.ExitIfError(err)
-
-		issueKey := args[0]
-
-		transitions, err := client.GetTransitions(ctx, issueKey)
-		if err != nil {
-			return err
-		}
-
-		if len(args) == 1 {
-			fmt.Println("Available transitions:")
-			for _, t := range transitions {
-				fmt.Printf("  %s -> %s\n", t.Name, t.To.Name)
-			}
-			return nil
-		}
-
-		transitionName := strings.ToLower(args[1])
-		var targetTransition *api.Transition
-
-		for _, t := range transitions {
-			if strings.ToLower(t.Name) == transitionName || strings.ToLower(t.To.Name) == transitionName {
-				targetTransition = &t
-				break
-			}
-		}
-
-		if targetTransition == nil {
-			return fmt.Errorf("transition '%s' not found", args[1])
-		}
-
-		fields := make(map[string]interface{})
-
-		if r, _ := cmd.Flags().GetString("resolution"); r != "" {
-			fields["resolution"] = map[string]string{"name": r}
-		}
-
-		if fv, _ := cmd.Flags().GetStringSlice("fix-version"); len(fv) > 0 {
-			versions := make([]map[string]string, len(fv))
-			for i, v := range fv {
-				versions[i] = map[string]string{"name": v}
-			}
-			fields["fixVersions"] = versions
-		}
-
-		if rawFields, _ := cmd.Flags().GetStringArray("field"); len(rawFields) > 0 {
-			for _, f := range rawFields {
-				parts := strings.SplitN(f, "=", 2)
-				if len(parts) != 2 {
-					return fmt.Errorf("invalid --field format %q, expected key=value", f)
-				}
-				val := parts[1]
-				if strings.HasPrefix(val, "[") || strings.HasPrefix(val, "{") {
-					var parsed interface{}
-					if err := json.Unmarshal([]byte(val), &parsed); err == nil {
-						fields[parts[0]] = parsed
-					} else {
-						fields[parts[0]] = val
-					}
-				} else {
-					fields[parts[0]] = val
-				}
-			}
-		}
-
-		err = client.TransitionIssue(ctx, issueKey, targetTransition.ID, fields)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Issue %s transitioned to %s\n", issueKey, targetTransition.To.Name)
-		return nil
-	},
-}
-
 var issueCommentCmd = &cobra.Command{
 	Use:   "comment [issue-key] [comment]",
 	Short: "Add a comment to a JIRA issue",
@@ -494,7 +410,12 @@ func init() {
 	issueCmd.AddCommand(issueTransitionCmd)
 	issueTransitionCmd.Flags().StringP("resolution", "R", "", "Resolution name (e.g. Done, Won't Fix)")
 	issueTransitionCmd.Flags().StringSlice("fix-version", nil, "Fix version(s) to set")
-	issueTransitionCmd.Flags().StringArray("field", nil, "Additional fields as key=value (repeatable)")
+	issueTransitionCmd.Flags().StringArrayP("field", "F", nil, "Screen field as 'name=value' or 'id=value' (repeatable, comma-separated for multi-select)")
+	issueTransitionCmd.Flags().StringP("comment", "m", "", "Comment to add with the transition")
+	issueTransitionCmd.Flags().StringP("time-spent", "T", "", "Log work with the transition (e.g. 2h, 30m, 1d)")
+	issueTransitionCmd.Flags().Bool("json", false, "Output transitions as JSON (list mode)")
+	issueTransitionCmd.Flags().Bool("dry-run", false, "Print the transition payload without executing")
+	issueTransitionCmd.Flags().Bool("no-defaults", false, "Ignore jira.transition_defaults from config")
 	issueCmd.AddCommand(issueCommentCmd)
 	issueCmd.AddCommand(issueCommentsCmd)
 	issueCmd.AddCommand(issuePrsCmd)

--- a/cmd/jira_create.go
+++ b/cmd/jira_create.go
@@ -52,8 +52,8 @@ parent, so --sprint is rejected by the server for sub-task types.
 
 Epic, sprint, and story points are stored in server-specific custom
 fields; they are resolved automatically from the JIRA field registry.`,
-	Example: `  atl issue create -t Story -s "【NPM.PO-XXX】story title" -e GAUSS-23743 --sprint 1946 --story-points 3
-  atl issue create -t Sub-dev-task -P GAUSS-24318 -s "【开发】dev subtask title"
+	Example: `  atl issue create -t Story -s "story title" -e MYPROJ-100 --sprint 1946 --story-points 3
+  atl issue create -t Sub-task -P MYPROJ-123 -s "dev subtask title"
   atl issue create -t Bug -s "crash on empty input" -y Critical -a me
   atl issue create -t Task -s "raw field example" --field 'customfield_10103=5'`,
 	Aliases: []string{"new"},

--- a/cmd/jira_create.go
+++ b/cmd/jira_create.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/lroolle/atlas-cli/api"
+	"github.com/lroolle/atlas-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	epicLinkSchema = "com.pyxis.greenhopper.jira:gh-epic-link"
+	sprintSchema   = "com.pyxis.greenhopper.jira:gh-sprint"
+)
+
+type issueCreateOptions struct {
+	Project     string
+	Type        string
+	Summary     string
+	Description string
+	Parent      string
+	Priority    string
+	Assignee    string
+	Epic        string
+	Sprint      int
+	StoryPoints float64
+	Labels      []string
+	FixVersions []string
+	Components  []string
+	RawFields   []string
+}
+
+// agileFieldIDs holds the server-specific custom field IDs for agile fields,
+// resolved at runtime from /rest/api/2/field.
+type agileFieldIDs struct {
+	EpicLink    string
+	Sprint      string
+	StoryPoints string
+}
+
+var issueCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a JIRA issue",
+	Long: `Create a JIRA issue (Story, Task, Bug, Sub-dev-task, ...).
+
+Sub-task types require --parent. Sub-tasks inherit sprint from their
+parent, so --sprint is rejected by the server for sub-task types.
+
+Epic, sprint, and story points are stored in server-specific custom
+fields; they are resolved automatically from the JIRA field registry.`,
+	Example: `  atl issue create -t Story -s "【NPM.PO-XXX】story title" -e GAUSS-23743 --sprint 1946 --story-points 3
+  atl issue create -t Sub-dev-task -P GAUSS-24318 -s "【开发】dev subtask title"
+  atl issue create -t Bug -s "crash on empty input" -y Critical -a me
+  atl issue create -t Task -s "raw field example" --field 'customfield_10103=5'`,
+	Aliases: []string{"new"},
+	Args:    cobra.NoArgs,
+	RunE:    runIssueCreate,
+}
+
+func runIssueCreate(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	opts := issueCreateOptions{}
+	opts.Project, _ = cmd.Flags().GetString("project")
+	opts.Type, _ = cmd.Flags().GetString("type")
+	opts.Summary, _ = cmd.Flags().GetString("summary")
+	opts.Description, _ = cmd.Flags().GetString("description")
+	opts.Parent, _ = cmd.Flags().GetString("parent")
+	opts.Priority, _ = cmd.Flags().GetString("priority")
+	opts.Assignee, _ = cmd.Flags().GetString("assignee")
+	opts.Epic, _ = cmd.Flags().GetString("epic")
+	opts.Sprint, _ = cmd.Flags().GetInt("sprint")
+	opts.StoryPoints, _ = cmd.Flags().GetFloat64("story-points")
+	opts.Labels, _ = cmd.Flags().GetStringArray("label")
+	opts.FixVersions, _ = cmd.Flags().GetStringSlice("fix-version")
+	opts.Components, _ = cmd.Flags().GetStringSlice("component")
+	opts.RawFields, _ = cmd.Flags().GetStringArray("field")
+
+	if opts.Project == "" {
+		opts.Project = viper.GetString("jira.default_project")
+	}
+	if opts.Project == "" {
+		return fmt.Errorf("project required: use --project or set jira.default_project in config")
+	}
+	if opts.Assignee == "me" {
+		opts.Assignee = viper.GetString("jira.username")
+		if opts.Assignee == "" {
+			opts.Assignee = viper.GetString("username")
+		}
+	}
+
+	client, err := api.GetJiraClient()
+	cmdutil.ExitIfError(err)
+
+	var agile agileFieldIDs
+	if opts.Epic != "" || opts.Sprint > 0 || opts.StoryPoints > 0 {
+		agile, err = resolveAgileFields(ctx, client)
+		if err != nil {
+			return err
+		}
+	}
+
+	fields, err := buildIssueFields(opts, agile)
+	if err != nil {
+		return err
+	}
+
+	created, err := client.CreateIssue(ctx, fields)
+	if err != nil {
+		return err
+	}
+
+	if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+		out := map[string]string{
+			"key": created.Key,
+			"id":  created.ID,
+			"url": client.BaseURL + "/browse/" + created.Key,
+		}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+	}
+
+	fmt.Printf("Created %s: %s\n", created.Key, opts.Summary)
+	fmt.Printf("URL: %s/browse/%s\n", client.BaseURL, created.Key)
+	return nil
+}
+
+// buildIssueFields maps create options onto the JIRA create-issue fields
+// payload. Agile field IDs are server-specific and passed in resolved.
+func buildIssueFields(opts issueCreateOptions, agile agileFieldIDs) (map[string]interface{}, error) {
+	if opts.Type == "" {
+		return nil, fmt.Errorf("--type required")
+	}
+	if opts.Summary == "" {
+		return nil, fmt.Errorf("--summary required")
+	}
+
+	fields := map[string]interface{}{
+		"project":   map[string]string{"key": opts.Project},
+		"issuetype": map[string]string{"name": opts.Type},
+		"summary":   opts.Summary,
+	}
+
+	if opts.Description != "" {
+		fields["description"] = opts.Description
+	}
+	if opts.Parent != "" {
+		fields["parent"] = map[string]string{"key": prefixIssueKey(opts.Parent, opts.Project)}
+	}
+	if opts.Priority != "" {
+		fields["priority"] = map[string]string{"name": opts.Priority}
+	}
+	if opts.Assignee != "" {
+		fields["assignee"] = map[string]string{"name": opts.Assignee}
+	}
+	if len(opts.Labels) > 0 {
+		fields["labels"] = opts.Labels
+	}
+	if len(opts.FixVersions) > 0 {
+		versions := make([]map[string]string, len(opts.FixVersions))
+		for i, v := range opts.FixVersions {
+			versions[i] = map[string]string{"name": v}
+		}
+		fields["fixVersions"] = versions
+	}
+	if len(opts.Components) > 0 {
+		components := make([]map[string]string, len(opts.Components))
+		for i, c := range opts.Components {
+			components[i] = map[string]string{"name": c}
+		}
+		fields["components"] = components
+	}
+
+	if opts.Epic != "" {
+		if agile.EpicLink == "" {
+			return nil, fmt.Errorf("epic link field not found on this JIRA instance")
+		}
+		fields[agile.EpicLink] = prefixIssueKey(opts.Epic, opts.Project)
+	}
+	if opts.Sprint > 0 {
+		if agile.Sprint == "" {
+			return nil, fmt.Errorf("sprint field not found on this JIRA instance")
+		}
+		fields[agile.Sprint] = opts.Sprint
+	}
+	if opts.StoryPoints > 0 {
+		if agile.StoryPoints == "" {
+			return nil, fmt.Errorf("story points field not found on this JIRA instance")
+		}
+		fields[agile.StoryPoints] = opts.StoryPoints
+	}
+
+	for _, f := range opts.RawFields {
+		parts := strings.SplitN(f, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --field format %q, expected key=value", f)
+		}
+		fields[parts[0]] = parseFieldValue(parts[1])
+	}
+
+	return fields, nil
+}
+
+// parseFieldValue decodes JSON-looking values so --field can pass
+// objects and arrays; anything else stays a plain string.
+func parseFieldValue(val string) interface{} {
+	if strings.HasPrefix(val, "[") || strings.HasPrefix(val, "{") {
+		var parsed interface{}
+		if err := json.Unmarshal([]byte(val), &parsed); err == nil {
+			return parsed
+		}
+	}
+	return val
+}
+
+// prefixIssueKey turns a bare issue number into PROJECT-NUMBER, matching
+// the auto-prefix behavior of `issue list --epic`.
+func prefixIssueKey(key, project string) string {
+	if !strings.Contains(key, "-") && project != "" {
+		return project + "-" + key
+	}
+	return key
+}
+
+func resolveAgileFields(ctx context.Context, client *api.JiraClient) (agileFieldIDs, error) {
+	jiraFields, err := client.GetFields(ctx)
+	if err != nil {
+		return agileFieldIDs{}, fmt.Errorf("resolving agile fields: %w", err)
+	}
+	return findAgileFields(jiraFields), nil
+}
+
+func findAgileFields(jiraFields []api.JiraField) agileFieldIDs {
+	var agile agileFieldIDs
+	for _, f := range jiraFields {
+		switch {
+		case f.Schema.Custom == epicLinkSchema:
+			agile.EpicLink = f.ID
+		case f.Schema.Custom == sprintSchema:
+			agile.Sprint = f.ID
+		case f.Custom && strings.EqualFold(f.Name, "Story Points"):
+			agile.StoryPoints = f.ID
+		}
+	}
+	return agile
+}
+
+func init() {
+	issueCmd.AddCommand(issueCreateCmd)
+
+	f := issueCreateCmd.Flags()
+	f.SortFlags = false
+
+	f.StringP("type", "t", "", "Issue type (Story, Task, Bug, Sub-dev-task, ...) (required)")
+	f.StringP("summary", "s", "", "Issue summary (required)")
+	f.StringP("project", "p", "", "Project key (default from config)")
+	f.StringP("description", "b", "", "Issue description")
+	f.StringP("parent", "P", "", "Parent issue key (required for sub-task types)")
+	f.StringP("priority", "y", "", "Priority name (Blocker, Critical, Major, Minor, Trivial)")
+	f.StringP("assignee", "a", "", "Assignee username (use 'me' for current user)")
+	f.StringP("epic", "e", "", "Epic link (issue key, auto-prefixes project if needed)")
+	f.Int("sprint", 0, "Sprint ID (not valid for sub-task types)")
+	f.Float64("story-points", 0, "Story points estimate")
+	f.StringArrayP("label", "l", nil, "Label (repeatable)")
+	f.StringSlice("fix-version", nil, "Fix version(s)")
+	f.StringSliceP("component", "C", nil, "Component(s)")
+	f.StringArray("field", nil, "Additional fields as key=value, value may be JSON (repeatable)")
+	f.Bool("json", false, "Output created issue as JSON")
+
+	_ = issueCreateCmd.MarkFlagRequired("type")
+	_ = issueCreateCmd.MarkFlagRequired("summary")
+}

--- a/cmd/jira_create_test.go
+++ b/cmd/jira_create_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBuildIssueFieldsMinimal(t *testing.T) {
 	fields, err := buildIssueFields(issueCreateOptions{
-		Project: "GAUSS",
+		Project: "MYPROJ",
 		Type:    "Story",
 		Summary: "test story",
 	}, agileFieldIDs{})
@@ -18,7 +18,7 @@ func TestBuildIssueFieldsMinimal(t *testing.T) {
 	}
 
 	want := map[string]interface{}{
-		"project":   map[string]string{"key": "GAUSS"},
+		"project":   map[string]string{"key": "MYPROJ"},
 		"issuetype": map[string]string{"name": "Story"},
 		"summary":   "test story",
 	}
@@ -32,11 +32,11 @@ func TestBuildIssueFieldsValidation(t *testing.T) {
 		name string
 		opts issueCreateOptions
 	}{
-		{"missing type", issueCreateOptions{Project: "GAUSS", Summary: "s"}},
-		{"missing summary", issueCreateOptions{Project: "GAUSS", Type: "Story"}},
-		{"epic without resolved field", issueCreateOptions{Project: "GAUSS", Type: "Story", Summary: "s", Epic: "GAUSS-1"}},
-		{"sprint without resolved field", issueCreateOptions{Project: "GAUSS", Type: "Story", Summary: "s", Sprint: 7}},
-		{"bad raw field", issueCreateOptions{Project: "GAUSS", Type: "Story", Summary: "s", RawFields: []string{"noequals"}}},
+		{"missing type", issueCreateOptions{Project: "MYPROJ", Summary: "s"}},
+		{"missing summary", issueCreateOptions{Project: "MYPROJ", Type: "Story"}},
+		{"epic without resolved field", issueCreateOptions{Project: "MYPROJ", Type: "Story", Summary: "s", Epic: "MYPROJ-1"}},
+		{"sprint without resolved field", issueCreateOptions{Project: "MYPROJ", Type: "Story", Summary: "s", Sprint: 7}},
+		{"bad raw field", issueCreateOptions{Project: "MYPROJ", Type: "Story", Summary: "s", RawFields: []string{"noequals"}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -49,9 +49,9 @@ func TestBuildIssueFieldsValidation(t *testing.T) {
 
 func TestBuildIssueFieldsSubtask(t *testing.T) {
 	fields, err := buildIssueFields(issueCreateOptions{
-		Project:  "GAUSS",
-		Type:     "Sub-dev-task",
-		Summary:  "【开发】dev work",
+		Project:  "MYPROJ",
+		Type:     "Sub-task",
+		Summary:  "dev subtask work",
 		Parent:   "24318",
 		Priority: "Major",
 	}, agileFieldIDs{})
@@ -60,8 +60,8 @@ func TestBuildIssueFieldsSubtask(t *testing.T) {
 	}
 
 	parent, ok := fields["parent"].(map[string]string)
-	if !ok || parent["key"] != "GAUSS-24318" {
-		t.Errorf("parent = %#v, want key GAUSS-24318 (auto-prefixed)", fields["parent"])
+	if !ok || parent["key"] != "MYPROJ-24318" {
+		t.Errorf("parent = %#v, want key MYPROJ-24318 (auto-prefixed)", fields["parent"])
 	}
 	priority, ok := fields["priority"].(map[string]string)
 	if !ok || priority["name"] != "Major" {
@@ -76,7 +76,7 @@ func TestBuildIssueFieldsAgile(t *testing.T) {
 		StoryPoints: "customfield_10103",
 	}
 	fields, err := buildIssueFields(issueCreateOptions{
-		Project:     "GAUSS",
+		Project:     "MYPROJ",
 		Type:        "Story",
 		Summary:     "agile story",
 		Epic:        "23743",
@@ -87,8 +87,8 @@ func TestBuildIssueFieldsAgile(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if fields["customfield_10501"] != "GAUSS-23743" {
-		t.Errorf("epic = %v, want GAUSS-23743", fields["customfield_10501"])
+	if fields["customfield_10501"] != "MYPROJ-23743" {
+		t.Errorf("epic = %v, want MYPROJ-23743", fields["customfield_10501"])
 	}
 	if fields["customfield_10401"] != 1946 {
 		t.Errorf("sprint = %v, want 1946", fields["customfield_10401"])
@@ -100,7 +100,7 @@ func TestBuildIssueFieldsAgile(t *testing.T) {
 
 func TestBuildIssueFieldsRawFieldJSON(t *testing.T) {
 	fields, err := buildIssueFields(issueCreateOptions{
-		Project: "GAUSS",
+		Project: "MYPROJ",
 		Type:    "Story",
 		Summary: "raw fields",
 		RawFields: []string{

--- a/cmd/jira_create_test.go
+++ b/cmd/jira_create_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/lroolle/atlas-cli/api"
+)
+
+func TestBuildIssueFieldsMinimal(t *testing.T) {
+	fields, err := buildIssueFields(issueCreateOptions{
+		Project: "GAUSS",
+		Type:    "Story",
+		Summary: "test story",
+	}, agileFieldIDs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"project":   map[string]string{"key": "GAUSS"},
+		"issuetype": map[string]string{"name": "Story"},
+		"summary":   "test story",
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestBuildIssueFieldsValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		opts issueCreateOptions
+	}{
+		{"missing type", issueCreateOptions{Project: "GAUSS", Summary: "s"}},
+		{"missing summary", issueCreateOptions{Project: "GAUSS", Type: "Story"}},
+		{"epic without resolved field", issueCreateOptions{Project: "GAUSS", Type: "Story", Summary: "s", Epic: "GAUSS-1"}},
+		{"sprint without resolved field", issueCreateOptions{Project: "GAUSS", Type: "Story", Summary: "s", Sprint: 7}},
+		{"bad raw field", issueCreateOptions{Project: "GAUSS", Type: "Story", Summary: "s", RawFields: []string{"noequals"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := buildIssueFields(tc.opts, agileFieldIDs{}); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestBuildIssueFieldsSubtask(t *testing.T) {
+	fields, err := buildIssueFields(issueCreateOptions{
+		Project:  "GAUSS",
+		Type:     "Sub-dev-task",
+		Summary:  "【开发】dev work",
+		Parent:   "24318",
+		Priority: "Major",
+	}, agileFieldIDs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	parent, ok := fields["parent"].(map[string]string)
+	if !ok || parent["key"] != "GAUSS-24318" {
+		t.Errorf("parent = %#v, want key GAUSS-24318 (auto-prefixed)", fields["parent"])
+	}
+	priority, ok := fields["priority"].(map[string]string)
+	if !ok || priority["name"] != "Major" {
+		t.Errorf("priority = %#v, want name Major", fields["priority"])
+	}
+}
+
+func TestBuildIssueFieldsAgile(t *testing.T) {
+	agile := agileFieldIDs{
+		EpicLink:    "customfield_10501",
+		Sprint:      "customfield_10401",
+		StoryPoints: "customfield_10103",
+	}
+	fields, err := buildIssueFields(issueCreateOptions{
+		Project:     "GAUSS",
+		Type:        "Story",
+		Summary:     "agile story",
+		Epic:        "23743",
+		Sprint:      1946,
+		StoryPoints: 3,
+	}, agile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fields["customfield_10501"] != "GAUSS-23743" {
+		t.Errorf("epic = %v, want GAUSS-23743", fields["customfield_10501"])
+	}
+	if fields["customfield_10401"] != 1946 {
+		t.Errorf("sprint = %v, want 1946", fields["customfield_10401"])
+	}
+	if fields["customfield_10103"] != 3.0 {
+		t.Errorf("story points = %v, want 3", fields["customfield_10103"])
+	}
+}
+
+func TestBuildIssueFieldsRawFieldJSON(t *testing.T) {
+	fields, err := buildIssueFields(issueCreateOptions{
+		Project: "GAUSS",
+		Type:    "Story",
+		Summary: "raw fields",
+		RawFields: []string{
+			`customfield_12113={"value":"商业论证"}`,
+			"customfield_10700=plain",
+		},
+	}, agileFieldIDs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj, ok := fields["customfield_12113"].(map[string]interface{})
+	if !ok || obj["value"] != "商业论证" {
+		t.Errorf("json raw field = %#v, want parsed object", fields["customfield_12113"])
+	}
+	if fields["customfield_10700"] != "plain" {
+		t.Errorf("plain raw field = %v, want plain", fields["customfield_10700"])
+	}
+}
+
+func TestFindAgileFields(t *testing.T) {
+	jiraFields := []api.JiraField{
+		{ID: "summary", Name: "Summary"},
+		{ID: "customfield_10501", Name: "Epic Link", Custom: true},
+		{ID: "customfield_10401", Name: "Sprint", Custom: true},
+		{ID: "customfield_10103", Name: "Story Points", Custom: true},
+	}
+	jiraFields[1].Schema.Custom = "com.pyxis.greenhopper.jira:gh-epic-link"
+	jiraFields[2].Schema.Custom = "com.pyxis.greenhopper.jira:gh-sprint"
+	jiraFields[3].Schema.Custom = "com.atlassian.jira.plugin.system.customfieldtypes:float"
+
+	agile := findAgileFields(jiraFields)
+
+	want := agileFieldIDs{
+		EpicLink:    "customfield_10501",
+		Sprint:      "customfield_10401",
+		StoryPoints: "customfield_10103",
+	}
+	if agile != want {
+		t.Errorf("agile = %+v, want %+v", agile, want)
+	}
+}

--- a/cmd/jira_transition.go
+++ b/cmd/jira_transition.go
@@ -1,0 +1,427 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/lroolle/atlas-cli/api"
+	"github.com/lroolle/atlas-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var issueTransitionCmd = &cobra.Command{
+	Use:   "transition [issue-key] [transition]",
+	Short: "Transition a JIRA issue to a new status",
+	Long: `Transition a JIRA issue through its workflow.
+
+Without a transition argument, lists available transitions including
+required fields and their allowed values.
+
+The transition argument matches (case-insensitive) the transition name,
+the target status name, the transition ID, or a unique substring:
+  atl issue transition MYPROJ-123 "Start Progress"
+  atl issue transition MYPROJ-123 resolve
+
+Fields on the transition screen can be set by display name or field ID;
+values are coerced to the right JSON shape from the field schema:
+  -F "Root Cause=config" -F "Test Level=unit,integration"
+  -F "Team Zone=Backend / Platform"            # cascading select
+  -F 'customfield_10001={"value":"config"}'    # raw JSON still works
+
+Team constants belong in config, not on the command line. Declare them
+under jira.transition_defaults keyed by issue type then transition name;
+they merge beneath CLI flags and skip fields not on the screen:
+
+  jira:
+    transition_defaults:
+      Bug:
+        start progress:
+          Team Zone: Backend / Platform
+          Story Points: 0
+          Original Estimate: 4h
+        resolve issue:
+          Fix Version/s: 1.2.0
+          Time Spent: 2h
+
+Use --dry-run to inspect the exact payload without transitioning, and
+--no-defaults to ignore the config block.`,
+	Example: `  atl issue transition MYPROJ-123
+  atl issue transition MYPROJ-123 --json
+  atl issue transition MYPROJ-123 "Start Progress"
+  atl issue transition MYPROJ-123 resolve -R Done --fix-version 1.2.0 -T 2h -m "fixed in abc123"
+  atl issue transition MYPROJ-123 close -R "Won't Fix" -F "Closure Reason=stale"
+
+Note: workflow validators may require fields beyond the ones marked
+required in list mode (e.g. Time Spent, Fix Version/s, checklist
+fields) — the server names them in the error; set them with -F/-T
+and retry.`,
+	Aliases: []string{"move", "mv"},
+	Args:    cobra.RangeArgs(1, 2),
+	RunE:    runIssueTransition,
+}
+
+func runIssueTransition(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	client, err := api.GetJiraClient()
+	cmdutil.ExitIfError(err)
+
+	issueKey := args[0]
+
+	transitions, err := client.GetTransitions(ctx, issueKey)
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 1 {
+		if asJSON, _ := cmd.Flags().GetBool("json"); asJSON {
+			return json.NewEncoder(os.Stdout).Encode(transitions)
+		}
+		printTransitions(ctx, client, issueKey, transitions)
+		return nil
+	}
+
+	target, err := matchTransition(transitions, args[1])
+	if err != nil {
+		return err
+	}
+
+	opts := transitionOptions{}
+	opts.Resolution, _ = cmd.Flags().GetString("resolution")
+	opts.FixVersions, _ = cmd.Flags().GetStringSlice("fix-version")
+	opts.RawFields, _ = cmd.Flags().GetStringArray("field")
+
+	update := api.TransitionUpdate{}
+	update.Comment, _ = cmd.Flags().GetString("comment")
+	update.TimeSpent, _ = cmd.Flags().GetString("time-spent")
+
+	if noDefaults, _ := cmd.Flags().GetBool("no-defaults"); !noDefaults {
+		issue, err := client.GetIssue(ctx, issueKey)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: skipping transition defaults, cannot read issue: %v\n", err)
+		} else {
+			opts.Defaults = transitionDefaults(issue.Fields.IssueType.Name, target.Name)
+		}
+	}
+	if ts, ok := popDefault(opts.Defaults, "Time Spent"); ok && update.TimeSpent == "" {
+		update.TimeSpent = ts
+	}
+	if est, ok := popDefault(opts.Defaults, "Original Estimate"); ok {
+		opts.Defaults["timetracking"] = est
+	}
+
+	fields, err := buildTransitionFields(opts, target)
+	if err != nil {
+		return err
+	}
+
+	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+		out := map[string]interface{}{
+			"issue": issueKey,
+			"to":    target.To.Name,
+			"body":  api.TransitionBody(target.ID, fields, update),
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	err = client.TransitionIssue(ctx, issueKey, target.ID, fields, update)
+	if err != nil {
+		printRequiredFieldsHint(target)
+		return err
+	}
+
+	fmt.Printf("Issue %s transitioned to %s\n", issueKey, target.To.Name)
+	return nil
+}
+
+// transitionDefaults reads jira.transition_defaults.<issue type>.<transition>
+// from config: a map of field display name (or id) -> value applied before
+// CLI flags. Viper lowercases keys; matching is case-insensitive throughout.
+func transitionDefaults(issueType, transitionName string) map[string]string {
+	root := viper.GetStringMap("jira.transition_defaults")
+	byType, ok := root[strings.ToLower(issueType)].(map[string]interface{})
+	if !ok {
+		if byType, ok = root["*"].(map[string]interface{}); !ok {
+			return nil
+		}
+	}
+	byTransition, ok := byType[strings.ToLower(transitionName)].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	defaults := make(map[string]string, len(byTransition))
+	for k, v := range byTransition {
+		defaults[k] = fmt.Sprintf("%v", v)
+	}
+	return defaults
+}
+
+func popDefault(defaults map[string]string, name string) (string, bool) {
+	for k, v := range defaults {
+		if strings.EqualFold(k, name) {
+			delete(defaults, k)
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func printTransitions(ctx context.Context, client *api.JiraClient, issueKey string, transitions []api.Transition) {
+	header := fmt.Sprintf("Transitions for %s", issueKey)
+	if issue, err := client.GetIssue(ctx, issueKey); err == nil {
+		header = fmt.Sprintf("Transitions for %s [%s / %s]", issueKey, issue.Fields.IssueType.Name, issue.Fields.Status.Name)
+	}
+	fmt.Println(header)
+
+	for _, t := range transitions {
+		fmt.Printf("  %-4s %-28s -> %s\n", t.ID, t.Name, t.To.Name)
+		for id, meta := range t.Fields {
+			if !meta.Required {
+				continue
+			}
+			line := fmt.Sprintf("       requires %s (%s)", meta.Name, id)
+			if vals := formatAllowedValues(meta.AllowedValues); vals != "" {
+				line += ": " + vals
+			}
+			fmt.Println(line)
+		}
+	}
+}
+
+type transitionOptions struct {
+	Resolution  string
+	FixVersions []string
+	RawFields   []string
+	// Defaults come from jira.transition_defaults config, lowest
+	// precedence, silently skipped when not on the transition screen.
+	Defaults map[string]string
+}
+
+// matchTransition finds a transition by exact name, target status name, or
+// ID (case-insensitive), falling back to a unique substring match.
+func matchTransition(transitions []api.Transition, arg string) (*api.Transition, error) {
+	needle := strings.ToLower(arg)
+
+	for i := range transitions {
+		t := &transitions[i]
+		if strings.ToLower(t.Name) == needle || strings.ToLower(t.To.Name) == needle || t.ID == arg {
+			return t, nil
+		}
+	}
+
+	var candidates []*api.Transition
+	for i := range transitions {
+		t := &transitions[i]
+		if strings.Contains(strings.ToLower(t.Name), needle) || strings.Contains(strings.ToLower(t.To.Name), needle) {
+			candidates = append(candidates, t)
+		}
+	}
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+	if len(candidates) > 1 {
+		names := make([]string, len(candidates))
+		for i, t := range candidates {
+			names[i] = fmt.Sprintf("%q", t.Name)
+		}
+		return nil, fmt.Errorf("transition %q is ambiguous: matches %s", arg, strings.Join(names, ", "))
+	}
+
+	available := make([]string, len(transitions))
+	for i, t := range transitions {
+		available[i] = fmt.Sprintf("%q -> %s", t.Name, t.To.Name)
+	}
+	return nil, fmt.Errorf("transition %q not found, available: %s", arg, strings.Join(available, ", "))
+}
+
+// buildTransitionFields assembles the fields payload. Keys in --field
+// entries may be field IDs or display names from the transition screen;
+// plain values are coerced to the JSON shape the field schema expects.
+func buildTransitionFields(opts transitionOptions, t *api.Transition) (map[string]interface{}, error) {
+	fields := make(map[string]interface{})
+
+	fromDefaults := make(map[string]bool)
+	for key, val := range opts.Defaults {
+		fieldID, meta, err := resolveTransitionField(t, key)
+		if err != nil || meta == nil {
+			continue // default's field is not on this transition's screen
+		}
+		fields[fieldID] = coerceTransitionValue(*meta, val)
+		fromDefaults[fieldID] = true
+	}
+
+	if opts.Resolution != "" {
+		fields["resolution"] = map[string]string{"name": opts.Resolution}
+	}
+
+	if len(opts.FixVersions) > 0 {
+		versions := make([]map[string]string, len(opts.FixVersions))
+		for i, v := range opts.FixVersions {
+			versions[i] = map[string]string{"name": v}
+		}
+		fields["fixVersions"] = versions
+	}
+
+	for _, f := range opts.RawFields {
+		parts := strings.SplitN(f, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --field format %q, expected key=value", f)
+		}
+		key, val := parts[0], parts[1]
+
+		fieldID, meta, err := resolveTransitionField(t, key)
+		if err != nil {
+			return nil, err
+		}
+
+		var value interface{}
+		if strings.HasPrefix(val, "[") || strings.HasPrefix(val, "{") {
+			var parsed interface{}
+			if err := json.Unmarshal([]byte(val), &parsed); err == nil {
+				value = parsed
+			} else {
+				value = val
+			}
+		} else if meta != nil {
+			value = coerceTransitionValue(*meta, val)
+		} else {
+			value = val
+		}
+
+		// Repeated flags for the same array field accumulate, but the
+		// first explicit flag replaces a config default entirely.
+		if prev, ok := fields[fieldID].([]interface{}); ok && !fromDefaults[fieldID] {
+			if next, ok := value.([]interface{}); ok {
+				fields[fieldID] = append(prev, next...)
+				continue
+			}
+		}
+		delete(fromDefaults, fieldID)
+		fields[fieldID] = value
+	}
+
+	return fields, nil
+}
+
+// resolveTransitionField maps a --field key to a field ID using the
+// transition screen metadata. Display names match case-insensitively.
+func resolveTransitionField(t *api.Transition, key string) (string, *api.TransitionField, error) {
+	if t != nil {
+		if meta, ok := t.Fields[key]; ok {
+			return key, &meta, nil
+		}
+		for id, meta := range t.Fields {
+			if strings.EqualFold(meta.Name, key) {
+				m := meta
+				return id, &m, nil
+			}
+		}
+	}
+
+	// Field IDs pass through untouched; an unresolved display name is an
+	// error because Jira would reject it with an opaque message anyway.
+	if strings.Contains(key, " ") {
+		var names []string
+		if t != nil {
+			for _, meta := range t.Fields {
+				names = append(names, meta.Name)
+			}
+		}
+		return "", nil, fmt.Errorf("field %q is not on the %q transition screen (available: %s)",
+			key, t.Name, strings.Join(names, ", "))
+	}
+	return key, nil, nil
+}
+
+// coerceTransitionValue converts a plain string value into the JSON shape
+// the field schema expects (option -> {"value": v}, version -> {"name": v},
+// arrays of those -> lists, comma-separated for multi-select fields).
+func coerceTransitionValue(meta api.TransitionField, raw string) interface{} {
+	switch meta.Schema.Type {
+	case "option":
+		return map[string]string{"value": raw}
+	case "option-with-child":
+		// Cascading select: "Parent / Child" (e.g. "Backend / Platform")
+		parent, child, hasChild := strings.Cut(raw, "/")
+		v := map[string]interface{}{"value": strings.TrimSpace(parent)}
+		if hasChild {
+			v["child"] = map[string]string{"value": strings.TrimSpace(child)}
+		}
+		return v
+	case "timetracking":
+		return map[string]string{"originalEstimate": raw}
+	case "resolution", "priority", "user", "version", "issuetype":
+		return map[string]string{"name": raw}
+	case "number":
+		if n, err := strconv.ParseFloat(raw, 64); err == nil {
+			return n
+		}
+		return raw
+	case "array":
+		// Only split on commas for fields with enumerated values;
+		// free-text arrays (e.g. labels-like) keep the raw string whole.
+		parts := []string{raw}
+		if len(meta.AllowedValues) > 0 || meta.Schema.Items == "version" {
+			parts = strings.Split(raw, ",")
+		}
+		out := make([]interface{}, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			switch meta.Schema.Items {
+			case "option":
+				out = append(out, map[string]string{"value": p})
+			case "version", "user", "group", "component":
+				out = append(out, map[string]string{"name": p})
+			default:
+				out = append(out, p)
+			}
+		}
+		return out
+	default:
+		return raw
+	}
+}
+
+const maxAllowedValuesShown = 12
+
+func formatAllowedValues(vals []api.AllowedValue) string {
+	if len(vals) == 0 {
+		return ""
+	}
+	shown := vals
+	extra := ""
+	if len(vals) > maxAllowedValuesShown {
+		shown = vals[:maxAllowedValuesShown]
+		extra = fmt.Sprintf(", … (+%d more)", len(vals)-maxAllowedValuesShown)
+	}
+	names := make([]string, len(shown))
+	for i, v := range shown {
+		names[i] = v.Display()
+	}
+	return strings.Join(names, ", ") + extra
+}
+
+func printRequiredFieldsHint(t *api.Transition) {
+	var lines []string
+	for id, meta := range t.Fields {
+		if !meta.Required {
+			continue
+		}
+		line := fmt.Sprintf("  %s (%s)", meta.Name, id)
+		if vals := formatAllowedValues(meta.AllowedValues); vals != "" {
+			line += ": " + vals
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Transition %q requires:\n%s\n", t.Name, strings.Join(lines, "\n"))
+}

--- a/cmd/jira_transition_test.go
+++ b/cmd/jira_transition_test.go
@@ -1,0 +1,320 @@
+package cmd
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/lroolle/atlas-cli/api"
+)
+
+func sampleTransitions() []api.Transition {
+	return []api.Transition{
+		{ID: "4", Name: "Start Progress", To: api.Status{Name: "In Development"}},
+		{ID: "711", Name: "Start Review", To: api.Status{Name: "In Review"}},
+		{
+			ID: "5", Name: "Resolve Issue", To: api.Status{Name: "Resolved"},
+			Fields: map[string]api.TransitionField{
+				"resolution": {
+					Required: true, Name: "Resolution",
+					Schema:        api.TransitionSchema{Type: "resolution"},
+					AllowedValues: []api.AllowedValue{{Name: "Done"}, {Name: "Fixed"}},
+				},
+				"customfield_12600": {
+					Name:          "Root Cause",
+					Schema:        api.TransitionSchema{Type: "option"},
+					AllowedValues: []api.AllowedValue{{Value: "功能缺陷"}, {Value: "性能缺陷"}},
+				},
+				"customfield_12301": {
+					Name:          "Test Level",
+					Schema:        api.TransitionSchema{Type: "array", Items: "option"},
+					AllowedValues: []api.AllowedValue{{Value: "Manual Test"}, {Value: "IT Auto"}},
+				},
+				"customfield_11202": {
+					Name:   "Analysis Notes",
+					Schema: api.TransitionSchema{Type: "array", Items: "string"},
+				},
+				"customfield_10103": {
+					Name:   "Story Points",
+					Schema: api.TransitionSchema{Type: "number"},
+				},
+			},
+		},
+		{ID: "2", Name: "Close Issue", To: api.Status{Name: "Closed"}},
+	}
+}
+
+func TestMatchTransition(t *testing.T) {
+	transitions := sampleTransitions()
+
+	cases := []struct {
+		arg  string
+		want string // expected transition ID
+	}{
+		{"Start Progress", "4"},
+		{"start progress", "4"},
+		{"In Development", "4"}, // target status name
+		{"711", "711"},          // transition ID
+		{"resolve", "5"},        // unique substring
+		{"closed", "2"},         // substring of target status
+	}
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			got, err := matchTransition(transitions, tc.arg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.ID != tc.want {
+				t.Errorf("matched ID = %s, want %s", got.ID, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchTransitionErrors(t *testing.T) {
+	transitions := sampleTransitions()
+
+	if _, err := matchTransition(transitions, "nonexistent"); err == nil {
+		t.Error("expected not-found error, got nil")
+	}
+	// "start" matches both "Start Progress" and "Start Review"
+	_, err := matchTransition(transitions, "start")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("expected ambiguous error, got %v", err)
+	}
+}
+
+func TestBuildTransitionFieldsFlags(t *testing.T) {
+	resolve := &sampleTransitions()[2]
+	fields, err := buildTransitionFields(transitionOptions{
+		Resolution:  "Done",
+		FixVersions: []string{"6.1.0"},
+	}, resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"resolution":  map[string]string{"name": "Done"},
+		"fixVersions": []map[string]string{{"name": "6.1.0"}},
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestBuildTransitionFieldsByName(t *testing.T) {
+	resolve := &sampleTransitions()[2]
+	fields, err := buildTransitionFields(transitionOptions{
+		RawFields: []string{
+			"Root Cause=功能缺陷",
+			"test level=Manual Test,IT Auto",
+			"Analysis Notes=race in sink, fixed by lock",
+			"Story Points=3",
+		},
+	}, resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"customfield_12600": map[string]string{"value": "功能缺陷"},
+		"customfield_12301": []interface{}{
+			map[string]string{"value": "Manual Test"},
+			map[string]string{"value": "IT Auto"},
+		},
+		// free-text array: comma NOT split
+		"customfield_11202": []interface{}{"race in sink, fixed by lock"},
+		"customfield_10103": float64(3),
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestBuildTransitionFieldsRawJSONAndID(t *testing.T) {
+	resolve := &sampleTransitions()[2]
+	fields, err := buildTransitionFields(transitionOptions{
+		RawFields: []string{
+			`customfield_12600={"value":"性能缺陷"}`,
+			"customfield_99999=freeform", // not on screen: passes through as string
+		},
+	}, resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"customfield_12600": map[string]interface{}{"value": "性能缺陷"},
+		"customfield_99999": "freeform",
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestBuildTransitionFieldsRepeatedArrayFlag(t *testing.T) {
+	resolve := &sampleTransitions()[2]
+	fields, err := buildTransitionFields(transitionOptions{
+		RawFields: []string{
+			"Analysis Notes=first finding",
+			"Analysis Notes=second finding",
+		},
+	}, resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"customfield_11202": []interface{}{"first finding", "second finding"},
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestBuildTransitionFieldsErrors(t *testing.T) {
+	resolve := &sampleTransitions()[2]
+
+	if _, err := buildTransitionFields(transitionOptions{RawFields: []string{"noequals"}}, resolve); err == nil {
+		t.Error("expected error for missing '=', got nil")
+	}
+	// Display-name-looking key not on the transition screen
+	if _, err := buildTransitionFields(transitionOptions{RawFields: []string{"No Such Field=x"}}, resolve); err == nil {
+		t.Error("expected error for unknown display name, got nil")
+	}
+}
+
+func startProgressTransition() *api.Transition {
+	return &api.Transition{
+		ID: "4", Name: "Start Progress", To: api.Status{Name: "In Development"},
+		Fields: map[string]api.TransitionField{
+			"customfield_12203": {Name: "Team Zone", Schema: api.TransitionSchema{Type: "option-with-child"}},
+			"customfield_12101": {Name: "Discipline", Schema: api.TransitionSchema{Type: "option"}},
+			"customfield_11201": {Name: "Squad", Schema: api.TransitionSchema{Type: "option"}},
+			"customfield_10103": {Name: "Story Points", Schema: api.TransitionSchema{Type: "number"}},
+			"versions":          {Name: "Affects Version/s", Schema: api.TransitionSchema{Type: "array", Items: "version"}},
+			"timetracking":      {Name: "Time Tracking", Schema: api.TransitionSchema{Type: "timetracking"}},
+		},
+	}
+}
+
+func TestBuildTransitionFieldsDefaults(t *testing.T) {
+	fields, err := buildTransitionFields(transitionOptions{
+		Defaults: map[string]string{
+			"team zone":         "Backend / Platform",
+			"discipline":        "Services",
+			"squad":             "Alpha",
+			"story points":      "0",
+			"affects version/s": "1.2.0",
+			"timetracking":      "4h",
+			"fix version/s":     "1.2.0", // not on this screen: skipped
+		},
+	}, startProgressTransition())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"customfield_12203": map[string]interface{}{
+			"value": "Backend",
+			"child": map[string]string{"value": "Platform"},
+		},
+		"customfield_12101": map[string]string{"value": "Services"},
+		"customfield_11201": map[string]string{"value": "Alpha"},
+		"customfield_10103": float64(0),
+		"versions":          []interface{}{map[string]string{"name": "1.2.0"}},
+		"timetracking":      map[string]string{"originalEstimate": "4h"},
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestBuildTransitionFieldsFlagOverridesDefault(t *testing.T) {
+	resolve := &sampleTransitions()[2]
+	fields, err := buildTransitionFields(transitionOptions{
+		Resolution: "Fixed",
+		RawFields:  []string{"Test Level=IT Auto"},
+		Defaults: map[string]string{
+			"resolution": "Done",
+			"test level": "Manual Test",
+			"root cause": "功能缺陷",
+		},
+	}, resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"resolution":        map[string]string{"name": "Fixed"},
+		"customfield_12301": []interface{}{map[string]string{"value": "IT Auto"}}, // replaced, not appended
+		"customfield_12600": map[string]string{"value": "功能缺陷"},
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestPopDefault(t *testing.T) {
+	defaults := map[string]string{"time spent": "2h", "team zone": "Backend"}
+	v, ok := popDefault(defaults, "Time Spent")
+	if !ok || v != "2h" {
+		t.Errorf("popDefault = %q, %v", v, ok)
+	}
+	if _, exists := defaults["time spent"]; exists {
+		t.Error("popDefault did not remove the key")
+	}
+	if _, ok := popDefault(nil, "Time Spent"); ok {
+		t.Error("popDefault on nil map should return false")
+	}
+}
+
+func TestCoerceTransitionValueScalar(t *testing.T) {
+	cases := []struct {
+		name string
+		meta api.TransitionField
+		raw  string
+		want interface{}
+	}{
+		{"option", api.TransitionField{Schema: api.TransitionSchema{Type: "option"}}, "建议", map[string]string{"value": "建议"}},
+		{"resolution", api.TransitionField{Schema: api.TransitionSchema{Type: "resolution"}}, "Done", map[string]string{"name": "Done"}},
+		{"user", api.TransitionField{Schema: api.TransitionSchema{Type: "user"}}, "eric.wang", map[string]string{"name": "eric.wang"}},
+		{"number", api.TransitionField{Schema: api.TransitionSchema{Type: "number"}}, "2.5", 2.5},
+		{"bad number stays string", api.TransitionField{Schema: api.TransitionSchema{Type: "number"}}, "abc", "abc"},
+		{"string", api.TransitionField{Schema: api.TransitionSchema{Type: "string"}}, "plain", "plain"},
+		{"cascading no child", api.TransitionField{Schema: api.TransitionSchema{Type: "option-with-child"}}, "Backend",
+			map[string]interface{}{"value": "Backend"}},
+		{"timetracking", api.TransitionField{Schema: api.TransitionSchema{Type: "timetracking"}}, "4h",
+			map[string]string{"originalEstimate": "4h"}},
+		{"version array", api.TransitionField{Schema: api.TransitionSchema{Type: "array", Items: "version"}}, "6.1.0, 6.2.0",
+			[]interface{}{map[string]string{"name": "6.1.0"}, map[string]string{"name": "6.2.0"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := coerceTransitionValue(tc.meta, tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("coerce(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatAllowedValues(t *testing.T) {
+	vals := []api.AllowedValue{{Name: "Done"}, {Value: "功能缺陷"}}
+	if got := formatAllowedValues(vals); got != "Done, 功能缺陷" {
+		t.Errorf("got %q", got)
+	}
+
+	var many []api.AllowedValue
+	for i := 0; i < 20; i++ {
+		many = append(many, api.AllowedValue{Name: "v"})
+	}
+	if got := formatAllowedValues(many); !strings.Contains(got, "+8 more") {
+		t.Errorf("expected truncation marker, got %q", got)
+	}
+
+	if got := formatAllowedValues(nil); got != "" {
+		t.Errorf("expected empty for nil, got %q", got)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,10 @@ var rootCmd = &cobra.Command{
 	Short:   "CLI for Atlassian REST API",
 	Long:    `Atlas CLI provides command-line access to Atlassian Bitbucket, JIRA, and Confluence REST APIs`,
 	Version: version.Full(),
+	// Execute() prints the error once; without these cobra prints it a
+	// second time plus the full usage text on every runtime API error.
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func Execute() {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,6 +20,25 @@ jira:
   default_project: MYPROJ       # Default project for issue commands
   # username: optional-different-username
 
+  # Team constants auto-filled on `issue transition`, keyed by issue type
+  # then transition name (matched case-insensitively). Use '*' as the
+  # issue-type key to apply to all types. Field keys are display names
+  # or IDs; values are coerced from the field schema (cascading selects
+  # use "Parent / Child"). CLI flags override; fields not on the
+  # transition screen are skipped. Special keys: "Time Spent" logs work,
+  # "Original Estimate" sets timetracking. Inspect the merged payload
+  # with --dry-run; disable with --no-defaults.
+  # transition_defaults:
+  #   Bug:
+  #     start progress:
+  #       Team Zone: Backend / Platform
+  #       Affects Version/s: 1.2.0
+  #       Story Points: 0
+  #       Original Estimate: 4h
+  #     resolve issue:
+  #       Fix Version/s: 1.2.0
+  #       Time Spent: 2h
+
 # Confluence configuration
 confluence:
   server: https://confluence.yourdomain.com

--- a/skills/atl-cli/SKILL.md
+++ b/skills/atl-cli/SKILL.md
@@ -101,10 +101,22 @@ atl page list ~john.doe        # WRONG
 # Positional arg, not --space
 atl page list '~john.doe'      # RIGHT
 atl page list --space SPACE    # WRONG
-
-# No CDATA in Confluence storage
-<pre>code</pre>                # RIGHT
-<![CDATA[code]]>               # WRONG
 ```
 
-Read `references/confluence-guidelines.md` before editing pages.
+## Confluence Pages -- Format Choice
+
+**Default to storage format (.html) for pages with code blocks or macros.**
+The markdown converter has known bugs: unescaped `&`, `<`, `>` in code fences
+cause HTTP 400. Use CDATA in storage format to protect special chars:
+
+```html
+<ac:structured-macro ac:name="code">
+  <ac:parameter ac:name="language">bash</ac:parameter>
+  <ac:plain-text-body><![CDATA[PASS='foo&bar']]></ac:plain-text-body>
+</ac:structured-macro>
+```
+
+Bare URLs are NOT auto-linked -- always use `<a href="...">text</a>`.
+
+Read `references/confluence-guidelines.md` for full layout patterns, panel macros,
+tables, and known bugs before creating or editing pages.

--- a/skills/atl-cli/SKILL.md
+++ b/skills/atl-cli/SKILL.md
@@ -15,9 +15,10 @@ atl
 ├── issue (jira)
 │   ├── list (ls, search) [text]      # -t -s[] -y -a -r -e -C -l[] -p -q --order-by --reverse --limit
 │   ├── view [key]
+│   ├── create                        # -t -s -P -y -a -e --sprint --story-points --field --json
 │   ├── comment [key] [text]
 │   ├── comments [key]
-│   ├── transition [key] [name?]      # Omit name to list available
+│   ├── transition (move, mv) [key] [name?]  # -R -F[] -T -m --fix-version --json
 │   └── prs [key]                     # Linked pull requests
 ├── page (confluence)
 │   ├── list [space]                  # --type --limit
@@ -55,6 +56,50 @@ atl issue list -q "created >= -7d"    # Raw JQL
 | `-a` | me, none, x, username |
 | `-e` | Epic key (auto-prefixes project) |
 | `--order-by` | created, updated, priority, status, key, assignee, reporter, summary |
+
+## Jira Issue Create
+
+```bash
+# Story with epic/sprint/points (agile field IDs auto-resolved per instance)
+atl issue create -t Story -s "story title" -e MYPROJ-100 --sprint 1946 --story-points 3
+
+# Sub-task under a story (subtask type names are server-specific)
+atl issue create -t Sub-task -P MYPROJ-123 -y Major -s "dev subtask"
+
+atl issue create -t Bug -s "crash on empty input" -y Critical -a me
+atl issue create -t Task -s "x" --field 'customfield_10001={"value":"internal"}' --json
+```
+
+Pitfalls: sub-tasks INHERIT sprint from parent (passing `--sprint` gets a
+400 — omit it). Dedup first: `atl issue view <parent>` shows existing
+subtasks. `--json` prints `{key,id,url}` for scripting.
+
+## Jira Workflow Transitions
+
+```bash
+atl issue transition MYPROJ-123                    # List transitions + required fields
+atl issue transition MYPROJ-123 --json             # Full field metadata (schema, allowed values)
+atl issue transition MYPROJ-123 "Start Progress"   # By name, target status, id, or unique substring
+atl issue transition MYPROJ-123 resolve -R Done --fix-version 1.2.0 -T 2h \
+  -F "Root Cause=config error" -m "merged in PR #123"
+```
+
+| Flag | Purpose |
+|------|---------|
+| `-R` | Resolution (required on Resolve/Close) |
+| `--fix-version` | Fix Version/s |
+| `-T` | Log work, e.g. 2h, 30m (validators often demand Time Spent) |
+| `-F` | Screen field by display name or id; values coerced from schema; repeatable; ASCII comma = multi-select separator; cascading selects as "Parent / Child" |
+| `-m` | Comment posted with the transition |
+| `--dry-run` | Print the exact POST body without transitioning |
+| `--no-defaults` | Ignore jira.transition_defaults from config |
+
+Workflow validators require fields the API never marks required — the
+400 names them; add the flags and retry. Put team-constant field values
+in `jira.transition_defaults` (config) so the CLI only carries what
+varies per issue. Read `references/jira-workflow.md` for the discovery
+methodology and config semantics BEFORE transitioning issues on an
+instance whose workflow you haven't mapped.
 
 ## Confluence Page Search
 

--- a/skills/atl-cli/references/confluence-guidelines.md
+++ b/skills/atl-cli/references/confluence-guidelines.md
@@ -7,69 +7,177 @@
 3. **No silent deletions**: Don't remove content without explicit permission
 4. **Check duplicates**: Search before creating new pages
 
+## Writing Pages -- Format Choice
+
+`atl page create -f file` accepts markdown (.md) or Confluence storage format (.html).
+
+**Default to storage format** for anything non-trivial. The markdown converter has
+known bugs (unescaped `&`, `<`, `>` in code fences cause XML parse errors / HTTP 400)
+and limited macro support. Markdown is fine for plain prose; storage format is required
+when your page has:
+
+- Code blocks containing `&`, `<`, `>`, or single quotes
+- Warning/info/note panels
+- Multi-column layouts
+- Tables inside macros
+- Anything beyond basic headings + paragraphs + lists
+
+### Workflow
+
+```bash
+# 1. Write content in storage format
+#    (see "Storage Format Reference" below)
+vi page.html
+
+# 2. Create
+atl page create -s '~eric.wang' -t "Page Title" -f page.html -p PARENT_ID
+
+# 3. Verify in browser
+atl page view PAGE_ID --web    # or open the URL manually
+```
+
+## Storage Format Reference
+
+### Minimal page skeleton
+
+```html
+<ac:structured-macro ac:name="info">
+  <ac:rich-text-body><p>Key message at the top.</p></ac:rich-text-body>
+</ac:structured-macro>
+
+<h2>Section</h2>
+<p>Paragraph text. <a href="http://example.com">Link text</a> for clickable URLs.</p>
+
+<ac:structured-macro ac:name="code">
+  <ac:parameter ac:name="language">bash</ac:parameter>
+  <ac:plain-text-body><![CDATA[echo "code goes here"
+special chars & < > are safe inside CDATA]]></ac:plain-text-body>
+</ac:structured-macro>
+```
+
+### Links -- always explicit
+
+Bare URLs are NOT auto-linked in Confluence storage format. Always wrap:
+
+```html
+<!-- WRONG -- renders as plain text -->
+<p>Open http://10.40.8.80/platform/ to check.</p>
+
+<!-- RIGHT -->
+<p>Open <a href="http://10.40.8.80/platform/">http://10.40.8.80/platform/</a> to check.</p>
+```
+
+### Code blocks
+
+Use `<ac:structured-macro ac:name="code">` with CDATA for the body.
+CDATA is the RIGHT way in storage format (it protects `&`, `<`, `>` from XML parsing).
+The old guidance "no CDATA" applied only to atl's markdown-to-storage converter path,
+which cannot handle CDATA in `-f markdown.md` input -- it's correct in raw storage.
+
+```html
+<ac:structured-macro ac:name="code">
+  <ac:parameter ac:name="language">bash</ac:parameter>
+  <ac:parameter ac:name="title">Optional title</ac:parameter>
+  <ac:plain-text-body><![CDATA[REDIS_PASS='0701!1523&SH'
+# & < > all safe here]]></ac:plain-text-body>
+</ac:structured-macro>
+```
+
+Supported `language` values: bash, python, go, java, sql, javascript, html, xml,
+json, yaml, toml, text, none.
+
+### Panels (info, warning, note, tip)
+
+```html
+<ac:structured-macro ac:name="warning">
+  <ac:rich-text-body>
+    <p>This page contains lab credentials. Do not forward.</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+
+<ac:structured-macro ac:name="info">
+  <ac:rich-text-body><p>Informational message.</p></ac:rich-text-body>
+</ac:structured-macro>
+```
+
+Panel types: `info` (blue), `note` (yellow), `warning` (red), `tip` (green).
+
+### Tables
+
+```html
+<table>
+  <thead><tr><th>Key</th><th>Value</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td>VIP</td><td>10.40.8.80</td><td>keepalived VRRP</td></tr>
+    <tr><td>Web Active</td><td>10.40.8.81</td><td>MASTER on healthy start</td></tr>
+  </tbody>
+</table>
+```
+
+### Horizontal rule
+
+```html
+<hr />
+```
+
 ## Suggested Page Structure
 
 ```
-{Page TOC}
+{Warning/info panel if needed}
 
-{Overview / Background / Context}
+{Overview table or key-value summary}
 
 ---
-{Section A}
+{Section A -- instructions or content}
 
 {Section B}
-
-{Section C}
 ---
 
-{Summary / Conclusion}
-
----
-
-{Reference Links}
+{Notes / caveats / links}
 ```
 
-Adapt to your organization's conventions.
+Keep it scannable. Engineers read Confluence pages like dashboards, not novels.
+Lead with the actionable content; put context and caveats at the bottom.
 
-## Storage Format Gotchas
+## Known Bugs (atl markdown mode)
 
-### Code Blocks
-```html
-<!-- WRONG - CDATA breaks in file upload -->
-<ac:structured-macro ac:name="code">
-  <ac:plain-text-body><![CDATA[code]]></ac:plain-text-body>
-</ac:structured-macro>
+| Bug | Symptom | Workaround |
+|-----|---------|------------|
+| Unescaped `&` in code fences | HTTP 400, empty error body | Use storage format with CDATA |
+| Unescaped `<` in code fences | Malformed XML, partial render | Same |
+| No macro support in markdown | Panels/columns silently dropped | Use storage format |
 
-<!-- RIGHT - simple pre tags -->
-<pre>code here</pre>
-```
+These are converter bugs in atl, not Confluence issues. Filed upstream.
 
-### Shell Expansion
+## Shell Gotchas
+
+### Tilde expansion
+
 ```bash
 # WRONG - tilde expands to home dir
-atl page create -s ~john.doe -t "Title" -c "<p>x</p>"
+atl page create -s ~john.doe -t "Title" -f page.html
 
 # RIGHT - quote the space key
-atl page create -s '~john.doe' -t "Title" -c "<p>x</p>"
+atl page create -s '~john.doe' -t "Title" -f page.html
 ```
 
-### Positional Arguments
+### Positional arguments
+
 ```bash
 # WRONG - page list takes positional space arg
 atl page list --space '~john.doe'
 
 # RIGHT
 atl page list '~john.doe'
-
-# Use search for filtering, not grep
-atl page search "notes" -s '~john.doe'
 ```
 
-### Duplicate Titles
+### Duplicate titles
+
 Confluence rejects duplicate titles in same space (400 error).
 Check first: `atl page search --title "Meeting Notes" -s SPACE`
 
 ## Limitations
 
-- No `atl page move` command - use Confluence UI
+- No `atl page move` -- use Confluence UI
 - Personal spaces use `~username` format (must be quoted in shell)
+- Markdown mode unreliable for pages with code blocks or macros -- use storage format

--- a/skills/atl-cli/references/jira-workflow.md
+++ b/skills/atl-cli/references/jira-workflow.md
@@ -1,0 +1,95 @@
+# Jira Workflow Transitions — discovery and defaults
+
+How to move issues through any Jira Server workflow with
+`atl issue transition` without hitting blind 400s. This is the generic
+methodology; encode your instance's specifics (state graph, per-type
+required fields, team constants) in your own config and team knowledge
+base, not in this skill.
+
+## Two kinds of "required"
+
+1. **Screen-required fields** — visible via the API. List mode shows
+   them per transition with allowed values:
+
+   ```bash
+   atl issue transition MYPROJ-123          # human-readable
+   atl issue transition MYPROJ-123 --json   # full schema + allowed values
+   ```
+
+2. **Validator-required fields** — enforced by workflow validators,
+   INVISIBLE to the REST API. They only surface when a transition POST
+   fails; the server names them ("Time Spent is required",
+   "customfield_10001: Root Cause is required"). No amount of metadata
+   introspection reveals them up front.
+
+So the fluent loop is: attempt -> read the named fields from the error ->
+add flags -> retry. The tool optimizes that loop rather than pretending
+it can pre-validate.
+
+## Discovering your instance's workflow
+
+One-time, per project (agents: do this when the knowledge base has no
+workflow map yet, and record the results there):
+
+1. `atl issue transition <key>` on issues of each type in each status —
+   maps the state graph and screen-required fields. Transition IDs
+   usually differ by source status; match by name.
+2. Attempt a transition on a throwaway/test issue with no fields — the
+   400 lists the validator-required fields for that type. This mutates
+   nothing when it fails.
+3. Sample recently resolved issues of each type and compare which
+   fields are consistently populated — that's the de-facto required
+   set, including pure team conventions validators don't enforce.
+
+## Transitioning
+
+```bash
+atl issue transition MYPROJ-123 "Start Progress"   # exact name
+atl issue transition MYPROJ-123 resolve            # unique substring
+atl issue transition MYPROJ-123 resolve -R Done --fix-version 1.2.0 -T 2h \
+  -F "Root Cause=config error" -m "fixed in abc123"
+```
+
+- `-R` resolution, `--fix-version` fix versions, `-T` logs work,
+  `-m` comments — all in the same transition POST.
+- `-F "name=value"` sets any screen field by display name or ID; values
+  are coerced from the field schema: options, multi-selects
+  (ASCII-comma separated), versions, users, numbers, cascading selects
+  (`"Parent / Child"`). Free-text array fields are never comma-split.
+  Repeat `-F` for the same field to accumulate. Raw JSON passes through.
+
+## Team constants belong in config
+
+Values that are the same on every transition (team/zone fields, story
+points conventions, estimates, current fix version) go in
+`~/.config/atlas/config.yaml`, keyed by issue type then transition name:
+
+```yaml
+jira:
+  transition_defaults:
+    Bug:
+      start progress:
+        Team Zone: Backend / Platform
+        Story Points: 0
+        Original Estimate: 4h
+      resolve issue:
+        Fix Version/s: 1.2.0
+        Time Spent: 2h
+    '*':                      # applies to types without their own block
+      resolve issue:
+        Fix Version/s: 1.2.0
+```
+
+Rules:
+- Defaults merge beneath CLI flags; an explicit flag replaces the
+  default for that field entirely.
+- Fields not on the target transition's screen are skipped silently, so
+  a `resolve issue` block is safe even when screens differ per type.
+- Special keys: `Time Spent` logs work, `Original Estimate` sets
+  timetracking.
+- `--no-defaults` ignores the block; `--dry-run` prints the exact POST
+  body (defaults merged) without transitioning — use it to verify a new
+  config block before first live use.
+
+The command line then carries only what genuinely varies per issue
+(resolution, analysis text, actual time spent).

--- a/skills/atl-cli/references/jira-workflow.md
+++ b/skills/atl-cli/references/jira-workflow.md
@@ -26,6 +26,23 @@ So the fluent loop is: attempt -> read the named fields from the error ->
 add flags -> retry. The tool optimizes that loop rather than pretending
 it can pre-validate.
 
+## Agent guardrails
+
+Transitions mutate team-visible state. Working agents follow these:
+
+1. List first (`atl issue transition <key>`) — see the real current
+   status and transitions. Never assume state; never hardcode IDs.
+2. `--dry-run` before the first real transition of a session or any
+   unfamiliar transition/type combo — inspect the merged payload.
+3. Only transition issues assigned to you or explicitly requested.
+4. On 400, add exactly the fields the error names and retry ONCE; if it
+   fails again, report instead of iterating blindly.
+5. Team constants belong in `jira.transition_defaults` config. If the
+   dry-run payload lacks expected defaults, the config block is missing
+   — say so rather than hand-typing values.
+6. Judgment fields (resolution, analysis text, checklist choices) must
+   reflect the actual work, not copied examples.
+
 ## Discovering your instance's workflow
 
 One-time, per project (agents: do this when the knowledge base has no


### PR DESCRIPTION
## Summary

- **Schema-aware transitions** with config defaults, worklog, dry-run (`atl issue transition`)
- **Issue create** command with full field support (`atl issue create`)
- **Subtask/parent display** in issue view
- **Field-setting on transitions** via `-R`, `-T`, `-F` flags
- **Skill docs**: Jira workflow guide, agent guardrails, Confluence storage format

## Changelog

```
feat(jira): schema-aware transitions with config defaults, worklog, dry-run
feat(jira): add issue create command
feat(jira): support setting fields on issue transition
feat(jira): add subtask and parent display to issue view
atl-cli skill: generic Jira transition guide
atl-cli skill: agent guardrails for issue transitions
atl-cli skill: Confluence storage format guidance
chore: abstract instance-specific examples and fixtures
```

## Test plan

- [x] `go test ./...` passes
- [x] `go build ./cmd/atl` compiles cleanly
- [ ] Manual: `atl issue transition GAUSS-xxx` with dry-run
- [ ] Manual: `atl issue create -p GAUSS -t Bug -s "test"`

Tagged as v0.2.0.