### PR TITLE
feat(pr): inline review comments anchored to diff lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,12 +543,25 @@ worth guessing against a live team PR.
 
 ---
 
+## Comment Lifecycle (2026-07-27)
+
+`atl pr comment --edit <id>` and `--delete <id>` close the loop opened by
+`--pending`: agent-drafted review comments can now be corrected or withdrawn
+without the web UI. Both fetch the comment first for its `version`
+(optimistic locking; the server answers 409 on a stale version, and delete
+409s on comments with replies). Verified live against a pending review
+comment (v0 -> v1 edit).
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-07-27 | Flags on `pr comment`, not a subcommand | `comment edit` would collide with the positional text argument |
+| 2026-07-27 | Edit replaces text only | Severity/state changes are separate concerns; smallest correct surface |
+
 ## Next Steps
 
 1. Add `page delete` command with confirmation
 2. Add `cmdutil.Confirm()` and spinner helpers
-3. Comment lifecycle: edit/delete (`PUT/DELETE .../comments/{id}`, needs version)
-4. Publish pending review (`PUT .../review`) once the payload is confirmed
+3. Publish pending review (`PUT .../review`) once the payload is confirmed
 5. Add `pr watch`/`unwatch` (low priority)
 6. Add `pr auto-merge` settings (low priority)
 7. Consider restructure after more commands exist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,13 @@ From `docs/api-specs/bitbucketserver.906.postman.json`:
 | Get pull request activity | GET .../activity | ✓ |
 | Stream raw diff | GET .../diff | ✓ |
 | Change participant status | PUT .../participants/{user} | ✓ |
+| Add comment (general/file/line/reply/task) | POST .../comments | ✓ |
+| Get comments for a path | GET .../comments?path= | ✓ |
+| Structured diff (JSON) | GET .../diff (Accept: json) | ✓ |
+| Get pending review | GET .../review | ✓ |
+| Discard pending review | DELETE .../review | ✓ |
+| Complete (publish) review | PUT .../review | missing (UI only) |
+| Edit/delete a comment | PUT/DELETE .../comments/{id} | missing |
 | Watch/Unwatch | POST/DELETE .../watch | missing |
 | Auto-merge settings | GET/POST/DELETE .../auto-merge | missing |
 
@@ -494,10 +501,54 @@ Summary:
 
 ---
 
+---
+
+## Inline PR Comments (2026-07-24)
+
+`atl pr comment` could only post general PR comments; every review had to
+spell out `file:line` inside the comment text. Bitbucket Server anchors
+comments through `anchor: {path, line, lineType, fileType, diffType,
+fromHash, toHash}`, and the anchor must match the diff or the comment lands
+orphaned.
+
+**Anchor resolution.** Callers pass a path and a line number as they read it
+in the file. `api/bitbucket_diff.go` fetches the structured diff
+(`GET .../diff` with `Accept: application/json`) and derives lineType and
+fileType from the segment the line falls in. Two facts the fixture encodes,
+both observed on the live server:
+
+- Added lines carry a `source` number and removed lines a `destination`
+  number, so side selection must filter on segment type, not on which line
+  number is populated.
+- Only lines inside the diff (changed plus context) can be anchored. The
+  resolver reports the file's commentable ranges instead of posting an
+  anchor the server would orphan. Resolution retries once with a wider
+  context before failing.
+
+**Safety.** Batches resolve every anchor before posting the first comment, so
+a bad path cannot half-post a review. `--dry-run` prints resolved anchors.
+`--pending` drafts comments that only the author sees, which is the right
+default for agent-authored reviews: a public comment notifies every reviewer
+and cannot be unsent. Publishing a pending review (`PUT .../review`) is left
+to the web UI; the payload is undocumented in the bundled spec and is not
+worth guessing against a live team PR.
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-07-24 | Resolve lineType/fileType from the diff, not from flags | Callers know the file, not the diff hunk shape |
+| 2026-07-24 | Fail on unanchorable lines instead of posting | Server silently orphans bad anchors |
+| 2026-07-24 | Resolve whole batch before posting any comment | Partial reviews are worse than none |
+| 2026-07-24 | Ship `--pending` + `--discard-pending`, not publish | Verifiable without notifying a team PR |
+| 2026-07-24 | Read comments via activities, not per-path | One request covers general, inline and replies |
+
+---
+
 ## Next Steps
 
 1. Add `page delete` command with confirmation
 2. Add `cmdutil.Confirm()` and spinner helpers
-3. Add `pr watch`/`unwatch` (low priority)
-4. Add `pr auto-merge` settings (low priority)
-5. Consider restructure after more commands exist
+3. Comment lifecycle: edit/delete (`PUT/DELETE .../comments/{id}`, needs version)
+4. Publish pending review (`PUT .../review`) once the payload is confirmed
+5. Add `pr watch`/`unwatch` (low priority)
+6. Add `pr auto-merge` settings (low priority)
+7. Consider restructure after more commands exist

--- a/api/bitbucket.go
+++ b/api/bitbucket.go
@@ -94,12 +94,16 @@ type PagedResponse struct {
 }
 
 type Comment struct {
-	ID          int    `json:"id"`
-	Version     int    `json:"version"`
-	Text        string `json:"text"`
-	Author      User   `json:"author"`
-	CreatedDate int64  `json:"createdDate"`
-	UpdatedDate int64  `json:"updatedDate"`
+	ID          int            `json:"id"`
+	Version     int            `json:"version"`
+	Text        string         `json:"text"`
+	Author      User           `json:"author"`
+	CreatedDate int64          `json:"createdDate"`
+	UpdatedDate int64          `json:"updatedDate"`
+	Severity    string         `json:"severity,omitempty"`
+	State       string         `json:"state,omitempty"`
+	Anchor      *CommentAnchor `json:"anchor,omitempty"`
+	Comments    []Comment      `json:"comments,omitempty"`
 }
 
 type Commit struct {
@@ -168,20 +172,10 @@ func (c *BitbucketClient) GetPullRequestDiff(ctx context.Context, project, repo 
 	return string(body), nil
 }
 
+// AddPullRequestComment posts a general comment on a pull request. Use
+// CreatePullRequestComment for anchored comments, replies and tasks.
 func (c *BitbucketClient) AddPullRequestComment(ctx context.Context, project, repo string, prID int, text string) (*Comment, error) {
-	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments", project, repo, prID)
-
-	body := map[string]string{
-		"text": text,
-	}
-
-	var comment Comment
-	err := c.Post(ctx, path, body, &comment)
-	if err != nil {
-		return nil, err
-	}
-
-	return &comment, nil
+	return c.CreatePullRequestComment(ctx, project, repo, prID, CommentRequest{Text: text})
 }
 
 func (c *BitbucketClient) ListCommits(ctx context.Context, project, repo string, limit int) ([]Commit, error) {
@@ -289,6 +283,9 @@ type Activity struct {
 	User        User     `json:"user"`
 	Action      string   `json:"action"`
 	Comment     *Comment `json:"comment,omitempty"`
+	// CommentAnchor is where the activity feed reports a comment's anchor;
+	// Comment.Anchor is not populated on this endpoint.
+	CommentAnchor *CommentAnchor `json:"commentAnchor,omitempty"`
 }
 
 type UpdatePROptions struct {

--- a/api/bitbucket_comment.go
+++ b/api/bitbucket_comment.go
@@ -135,3 +135,45 @@ func (c *BitbucketClient) DiscardPendingReview(ctx context.Context, project, rep
 	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/review", project, repo, prID)
 	return c.Delete(ctx, path)
 }
+
+// GetPullRequestComment returns a single comment, including the version
+// required by update and delete.
+func (c *BitbucketClient) GetPullRequestComment(ctx context.Context, project, repo string, prID, commentID int) (*Comment, error) {
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d", project, repo, prID, commentID)
+
+	var comment Comment
+	if err := c.Get(ctx, path, nil, &comment); err != nil {
+		return nil, err
+	}
+
+	return &comment, nil
+}
+
+// UpdatePullRequestComment replaces a comment's text. The version comes from
+// the current comment (optimistic locking); on a version conflict the server
+// answers 409.
+func (c *BitbucketClient) UpdatePullRequestComment(ctx context.Context, project, repo string, prID, commentID, version int, text string) (*Comment, error) {
+	if text == "" {
+		return nil, fmt.Errorf("comment text required")
+	}
+
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d", project, repo, prID, commentID)
+	body := struct {
+		Text    string `json:"text"`
+		Version int    `json:"version"`
+	}{Text: text, Version: version}
+
+	var comment Comment
+	if err := c.Put(ctx, path, body, &comment); err != nil {
+		return nil, err
+	}
+
+	return &comment, nil
+}
+
+// DeletePullRequestComment removes a comment at the given version. Comments
+// with replies cannot be deleted; the server answers 409.
+func (c *BitbucketClient) DeletePullRequestComment(ctx context.Context, project, repo string, prID, commentID, version int) error {
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d?version=%d", project, repo, prID, commentID, version)
+	return c.Delete(ctx, path)
+}

--- a/api/bitbucket_comment.go
+++ b/api/bitbucket_comment.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// Comment severity. BLOCKER comments are tasks: they block the merge until
+// they are resolved.
+const (
+	SeverityNormal  = "NORMAL"
+	SeverityBlocker = "BLOCKER"
+)
+
+// Comment state. PENDING comments belong to an unpublished review and are only
+// visible to their author until the review is completed.
+const (
+	CommentStateOpen     = "OPEN"
+	CommentStatePending  = "PENDING"
+	CommentStateResolved = "RESOLVED"
+)
+
+// CommentAnchor pins a comment to a file, or to a single line within a file.
+type CommentAnchor struct {
+	DiffType string `json:"diffType,omitempty"`
+	LineType string `json:"lineType,omitempty"`
+	FileType string `json:"fileType,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Path     string `json:"path,omitempty"`
+	SrcPath  string `json:"srcPath,omitempty"`
+	FromHash string `json:"fromHash,omitempty"`
+	ToHash   string `json:"toHash,omitempty"`
+	// Orphaned is set by the server when the anchored line no longer exists
+	// in the current diff, e.g. after a force push.
+	Orphaned bool `json:"orphaned,omitempty"`
+}
+
+// Location renders the anchor as path:line for display.
+func (a *CommentAnchor) Location() string {
+	if a == nil || a.Path == "" {
+		return ""
+	}
+	if a.Line == 0 {
+		return a.Path
+	}
+	return fmt.Sprintf("%s:%d", a.Path, a.Line)
+}
+
+type CommentParent struct {
+	ID int `json:"id"`
+}
+
+// CommentRequest is the payload for creating a pull request comment. Anchor
+// and Parent are mutually exclusive: a reply inherits its parent's anchor.
+type CommentRequest struct {
+	Text     string         `json:"text"`
+	Parent   *CommentParent `json:"parent,omitempty"`
+	Anchor   *CommentAnchor `json:"anchor,omitempty"`
+	Severity string         `json:"severity,omitempty"`
+	State    string         `json:"state,omitempty"`
+}
+
+// CreatePullRequestComment posts a comment. Depending on the request it lands
+// as a general comment, a file comment, a line comment or a reply.
+func (c *BitbucketClient) CreatePullRequestComment(ctx context.Context, project, repo string, prID int, req CommentRequest) (*Comment, error) {
+	if req.Text == "" {
+		return nil, fmt.Errorf("comment text required")
+	}
+	if req.Parent != nil && req.Anchor != nil {
+		return nil, fmt.Errorf("a reply cannot carry its own anchor")
+	}
+
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments", project, repo, prID)
+
+	var comment Comment
+	if err := c.Post(ctx, path, req, &comment); err != nil {
+		return nil, err
+	}
+
+	return &comment, nil
+}
+
+// GetPullRequestCommentsForPath returns the comments anchored to one file.
+// anchorState is ACTIVE, ORPHANED or ALL.
+func (c *BitbucketClient) GetPullRequestCommentsForPath(ctx context.Context, project, repo string, prID int, filePath, anchorState string, limit int) ([]Comment, error) {
+	params := url.Values{}
+	params.Set("path", filePath)
+	if anchorState != "" {
+		params.Set("anchorState", anchorState)
+	}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments", project, repo, prID)
+
+	var response struct {
+		Values []Comment `json:"values"`
+	}
+
+	if err := c.Get(ctx, path, params, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Values, nil
+}
+
+// GetPendingReview returns the authenticated user's unpublished review
+// comments on a pull request. Unlike the activity feed, this endpoint carries
+// each comment's anchor on the comment itself.
+func (c *BitbucketClient) GetPendingReview(ctx context.Context, project, repo string, prID, limit int) ([]Comment, error) {
+	params := url.Values{}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/review", project, repo, prID)
+
+	var response struct {
+		Values []Comment `json:"values"`
+	}
+
+	if err := c.Get(ctx, path, params, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Values, nil
+}
+
+// DiscardPendingReview drops every pending comment the authenticated user has
+// drafted on a pull request.
+func (c *BitbucketClient) DiscardPendingReview(ctx context.Context, project, repo string, prID int) error {
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/review", project, repo, prID)
+	return c.Delete(ctx, path)
+}

--- a/api/bitbucket_comment_test.go
+++ b/api/bitbucket_comment_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreatePullRequestCommentSendsAnchor(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":331,"version":0,"text":"this allocation leaks"}`))
+	}))
+	defer server.Close()
+
+	client := NewBitbucketClient(server.URL, "tester", "token")
+	client.HTTPClient = server.Client()
+
+	comment, err := client.CreatePullRequestComment(context.Background(), "MYPROJ", "myrepo", 140, CommentRequest{
+		Text:     "this allocation leaks",
+		Severity: SeverityBlocker,
+		Anchor: &CommentAnchor{
+			DiffType: DiffTypeEffective,
+			LineType: SegmentAdded,
+			FileType: FileTypeTo,
+			Line:     543,
+			Path:     "src/app.js",
+			FromHash: "aaa111base",
+			ToHash:   "bbb222head",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreatePullRequestComment returned error: %v", err)
+	}
+	if comment.ID != 331 {
+		t.Errorf("comment ID = %d, want 331", comment.ID)
+	}
+
+	wantPath := "/rest/api/1.0/projects/MYPROJ/repos/myrepo/pull-requests/140/comments"
+	if gotPath != wantPath {
+		t.Errorf("path = %q, want %q", gotPath, wantPath)
+	}
+	if gotBody["severity"] != SeverityBlocker {
+		t.Errorf("severity = %v, want %s", gotBody["severity"], SeverityBlocker)
+	}
+
+	anchor, ok := gotBody["anchor"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("anchor missing from request body: %v", gotBody)
+	}
+	if anchor["line"] != float64(543) || anchor["lineType"] != SegmentAdded || anchor["fileType"] != FileTypeTo {
+		t.Errorf("anchor = %v, want line 543 ADDED/TO", anchor)
+	}
+	if _, ok := anchor["srcPath"]; ok {
+		t.Error("srcPath sent for a file that was not renamed")
+	}
+	if _, ok := anchor["orphaned"]; ok {
+		t.Error("orphaned is server state and must not be sent")
+	}
+}
+
+func TestCreatePullRequestCommentReply(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":53240}`))
+	}))
+	defer server.Close()
+
+	client := NewBitbucketClient(server.URL, "tester", "token")
+	client.HTTPClient = server.Client()
+
+	_, err := client.CreatePullRequestComment(context.Background(), "MYPROJ", "myrepo", 140, CommentRequest{
+		Text:   "fixed in a1b2c3d",
+		Parent: &CommentParent{ID: 331},
+	})
+	if err != nil {
+		t.Fatalf("CreatePullRequestComment returned error: %v", err)
+	}
+
+	parent, ok := gotBody["parent"].(map[string]interface{})
+	if !ok || parent["id"] != float64(331) {
+		t.Errorf("parent = %v, want id 331", gotBody["parent"])
+	}
+	if _, ok := gotBody["anchor"]; ok {
+		t.Error("reply must not carry an anchor")
+	}
+}
+
+func TestCreatePullRequestCommentRejectsAnchoredReply(t *testing.T) {
+	client := NewBitbucketClient("https://git.example.com", "tester", "token")
+
+	_, err := client.CreatePullRequestComment(context.Background(), "MYPROJ", "myrepo", 140, CommentRequest{
+		Text:   "both at once",
+		Parent: &CommentParent{ID: 1},
+		Anchor: &CommentAnchor{Path: "src/app.js"},
+	})
+	if err == nil {
+		t.Fatal("expected an error for a reply carrying its own anchor")
+	}
+}
+
+func TestCommentAnchorLocation(t *testing.T) {
+	tests := []struct {
+		name   string
+		anchor *CommentAnchor
+		want   string
+	}{
+		{name: "nil anchor", anchor: nil, want: ""},
+		{name: "general comment", anchor: &CommentAnchor{}, want: ""},
+		{name: "file comment", anchor: &CommentAnchor{Path: "src/app.js"}, want: "src/app.js"},
+		{name: "line comment", anchor: &CommentAnchor{Path: "src/app.js", Line: 543}, want: "src/app.js:543"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.anchor.Location(); got != tt.want {
+				t.Errorf("Location() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/bitbucket_diff.go
+++ b/api/bitbucket_diff.go
@@ -1,0 +1,273 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Segment types returned by the structured diff endpoint.
+const (
+	SegmentContext = "CONTEXT"
+	SegmentAdded   = "ADDED"
+	SegmentRemoved = "REMOVED"
+)
+
+// Anchor file sides. FROM is the source (pre-change) file, TO the destination.
+const (
+	FileTypeFrom = "FROM"
+	FileTypeTo   = "TO"
+)
+
+const (
+	DiffTypeEffective = "EFFECTIVE"
+	DiffTypeCommit    = "COMMIT"
+	DiffTypeRange     = "RANGE"
+)
+
+// DiffSide selects which side of the diff a line number refers to.
+type DiffSide string
+
+const (
+	SideNew DiffSide = "new"
+	SideOld DiffSide = "old"
+)
+
+func ParseDiffSide(s string) (DiffSide, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "new", "to", "destination":
+		return SideNew, nil
+	case "old", "from", "source":
+		return SideOld, nil
+	default:
+		return "", fmt.Errorf("invalid side %q: use 'new' or 'old'", s)
+	}
+}
+
+// Diff is the structured (JSON) form of a pull request diff.
+type Diff struct {
+	FromHash  string     `json:"fromHash"`
+	ToHash    string     `json:"toHash"`
+	Diffs     []FileDiff `json:"diffs"`
+	Truncated bool       `json:"truncated"`
+}
+
+type FileDiff struct {
+	Source      *Path  `json:"source"`
+	Destination *Path  `json:"destination"`
+	Hunks       []Hunk `json:"hunks"`
+	Truncated   bool   `json:"truncated"`
+}
+
+type Hunk struct {
+	Context         string    `json:"context"`
+	SourceLine      int       `json:"sourceLine"`
+	SourceSpan      int       `json:"sourceSpan"`
+	DestinationLine int       `json:"destinationLine"`
+	DestinationSpan int       `json:"destinationSpan"`
+	Segments        []Segment `json:"segments"`
+	Truncated       bool      `json:"truncated"`
+}
+
+type Segment struct {
+	Type      string     `json:"type"`
+	Lines     []DiffLine `json:"lines"`
+	Truncated bool       `json:"truncated"`
+}
+
+type DiffLine struct {
+	Source      int    `json:"source"`
+	Destination int    `json:"destination"`
+	Line        string `json:"line"`
+	Truncated   bool   `json:"truncated"`
+}
+
+// GetPullRequestDiffJSON fetches the effective diff as structured JSON.
+// contextLines controls how many unchanged lines surround each hunk, which
+// determines how far from a change a comment can still be anchored.
+func (c *BitbucketClient) GetPullRequestDiffJSON(ctx context.Context, project, repo string, prID, contextLines int) (*Diff, error) {
+	params := url.Values{}
+	if contextLines > 0 {
+		params.Set("contextLines", strconv.Itoa(contextLines))
+	}
+
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/diff", project, repo, prID)
+
+	var diff Diff
+	if err := c.Get(ctx, path, params, &diff); err != nil {
+		return nil, err
+	}
+
+	return &diff, nil
+}
+
+// Paths lists every file path present in the diff, destination side first.
+func (d *Diff) Paths() []string {
+	paths := make([]string, 0, len(d.Diffs))
+	for i := range d.Diffs {
+		paths = append(paths, d.Diffs[i].Path())
+	}
+	return paths
+}
+
+// FindFile locates a file in the diff by destination or source path.
+func (d *Diff) FindFile(path string) *FileDiff {
+	path = strings.TrimPrefix(strings.TrimSpace(path), "./")
+
+	for i := range d.Diffs {
+		fd := &d.Diffs[i]
+		if fd.Destination != nil && fd.Destination.ToString == path {
+			return fd
+		}
+		if fd.Source != nil && fd.Source.ToString == path {
+			return fd
+		}
+	}
+
+	return nil
+}
+
+// Path is the path a comment anchor should use: the destination path, falling
+// back to the source path for deleted files.
+func (f *FileDiff) Path() string {
+	if f.Destination != nil {
+		return f.Destination.ToString
+	}
+	if f.Source != nil {
+		return f.Source.ToString
+	}
+	return ""
+}
+
+// SrcPath is the pre-change path, set only for copies and moves.
+func (f *FileDiff) SrcPath() string {
+	if f.Source == nil || f.Destination == nil {
+		return ""
+	}
+	if f.Source.ToString == f.Destination.ToString {
+		return ""
+	}
+	return f.Source.ToString
+}
+
+// LineRanges reports the line ranges of the given side that the diff covers,
+// i.e. the lines a comment can be anchored to.
+func (f *FileDiff) LineRanges(side DiffSide) []string {
+	ranges := make([]string, 0, len(f.Hunks))
+	for _, h := range f.Hunks {
+		start, span := h.DestinationLine, h.DestinationSpan
+		if side == SideOld {
+			start, span = h.SourceLine, h.SourceSpan
+		}
+		if span <= 0 {
+			continue
+		}
+		ranges = append(ranges, fmt.Sprintf("%d-%d", start, start+span-1))
+	}
+	return ranges
+}
+
+// ErrPathNotInDiff reports a file that the pull request does not touch.
+type ErrPathNotInDiff struct {
+	Path      string
+	Available []string
+}
+
+func (e *ErrPathNotInDiff) Error() string {
+	msg := fmt.Sprintf("%q is not part of this pull request's diff", e.Path)
+	if len(e.Available) > 0 {
+		msg += "\nchanged files:\n  " + strings.Join(e.Available, "\n  ")
+	}
+	return msg
+}
+
+// ErrLineNotInDiff reports a line that exists in the file but not in the diff
+// context, so Bitbucket cannot anchor a comment to it.
+type ErrLineNotInDiff struct {
+	Path   string
+	Line   int
+	Side   DiffSide
+	Ranges []string
+}
+
+func (e *ErrLineNotInDiff) Error() string {
+	msg := fmt.Sprintf("line %d (%s side) is not in the diff for %s", e.Line, e.Side, e.Path)
+	if len(e.Ranges) > 0 {
+		msg += fmt.Sprintf("\ncommentable lines: %s", strings.Join(e.Ranges, ", "))
+	}
+	return msg + "\n(comments can only be anchored to changed lines or their surrounding context)"
+}
+
+// ResolveFileAnchor builds a file-level anchor: a comment on the file as a
+// whole rather than on one of its lines.
+func (d *Diff) ResolveFileAnchor(path string) (*CommentAnchor, error) {
+	fd := d.FindFile(path)
+	if fd == nil {
+		return nil, &ErrPathNotInDiff{Path: path, Available: d.Paths()}
+	}
+
+	return d.baseAnchor(fd), nil
+}
+
+// ResolveLineAnchor finds line on the requested side of the diff and returns
+// the anchor Bitbucket needs to pin a comment to it. The line type (ADDED,
+// REMOVED, CONTEXT) is derived from the diff, so callers only need a path and
+// a line number as they read it in the file.
+func (d *Diff) ResolveLineAnchor(path string, line int, side DiffSide) (*CommentAnchor, error) {
+	fd := d.FindFile(path)
+	if fd == nil {
+		return nil, &ErrPathNotInDiff{Path: path, Available: d.Paths()}
+	}
+
+	for _, h := range fd.Hunks {
+		for _, s := range h.Segments {
+			for _, l := range s.Lines {
+				lineNo, fileType := l.Destination, FileTypeTo
+				if side == SideOld {
+					lineNo, fileType = l.Source, FileTypeFrom
+				}
+				if lineNo != line || !segmentHasSide(s.Type, side) {
+					continue
+				}
+
+				anchor := d.baseAnchor(fd)
+				anchor.Line = lineNo
+				anchor.LineType = s.Type
+				anchor.FileType = fileType
+				return anchor, nil
+			}
+		}
+	}
+
+	return nil, &ErrLineNotInDiff{
+		Path:   fd.Path(),
+		Line:   line,
+		Side:   side,
+		Ranges: fd.LineRanges(side),
+	}
+}
+
+// segmentHasSide reports whether a segment exists on the given side of the
+// diff: added lines only exist in the new file, removed lines only in the old.
+func segmentHasSide(segmentType string, side DiffSide) bool {
+	switch segmentType {
+	case SegmentAdded:
+		return side == SideNew
+	case SegmentRemoved:
+		return side == SideOld
+	default:
+		return true
+	}
+}
+
+func (d *Diff) baseAnchor(fd *FileDiff) *CommentAnchor {
+	return &CommentAnchor{
+		DiffType: DiffTypeEffective,
+		Path:     fd.Path(),
+		SrcPath:  fd.SrcPath(),
+		FromHash: d.FromHash,
+		ToHash:   d.ToHash,
+	}
+}

--- a/api/bitbucket_diff_test.go
+++ b/api/bitbucket_diff_test.go
@@ -1,0 +1,275 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// diffFixture mirrors the shape Bitbucket Server returns for
+// GET /pull-requests/{id}/diff: one modified file, one renamed file.
+const diffFixture = `{
+  "fromHash": "aaa111base",
+  "toHash": "bbb222head",
+  "contextLines": 10,
+  "diffs": [
+    {
+      "source": {"toString": "src/app.js"},
+      "destination": {"toString": "src/app.js"},
+      "hunks": [
+        {
+          "sourceLine": 540,
+          "sourceSpan": 4,
+          "destinationLine": 540,
+          "destinationSpan": 5,
+          "segments": [
+            {"type": "CONTEXT", "lines": [
+              {"source": 540, "destination": 540, "line": "function peakUnit(u) {"},
+              {"source": 541, "destination": 541, "line": "  const x = 1"}
+            ]},
+            {"type": "REMOVED", "lines": [
+              {"source": 542, "destination": 541, "line": "  return u + '_peak'"}
+            ]},
+            {"type": "ADDED", "lines": [
+              {"source": 542, "destination": 542, "line": "  return stripPeak(u)"},
+              {"source": 542, "destination": 543, "line": "  // FIXME"}
+            ]},
+            {"type": "CONTEXT", "lines": [
+              {"source": 543, "destination": 544, "line": "}"}
+            ]}
+          ]
+        }
+      ]
+    },
+    {
+      "source": {"toString": "src/old/toolbar.vue"},
+      "destination": {"toString": "src/new/toolbar.vue"},
+      "hunks": [
+        {
+          "sourceLine": 10,
+          "sourceSpan": 2,
+          "destinationLine": 10,
+          "destinationSpan": 2,
+          "segments": [
+            {"type": "ADDED", "lines": [
+              {"source": 10, "destination": 10, "line": "const algo = ref('avg')"}
+            ]},
+            {"type": "CONTEXT", "lines": [
+              {"source": 10, "destination": 11, "line": "</script>"}
+            ]}
+          ]
+        }
+      ]
+    }
+  ]
+}`
+
+func testDiff(t *testing.T) *Diff {
+	t.Helper()
+
+	var diff Diff
+	if err := json.Unmarshal([]byte(diffFixture), &diff); err != nil {
+		t.Fatalf("decoding fixture: %v", err)
+	}
+	return &diff
+}
+
+func TestResolveLineAnchor(t *testing.T) {
+	diff := testDiff(t)
+
+	tests := []struct {
+		name     string
+		path     string
+		line     int
+		side     DiffSide
+		wantLine int
+		wantType string
+		wantFile string
+		wantSrc  string
+	}{
+		{
+			name: "added line on the new side",
+			path: "src/app.js", line: 542, side: SideNew,
+			wantLine: 542, wantType: SegmentAdded, wantFile: FileTypeTo,
+		},
+		{
+			name: "context line on the new side",
+			path: "src/app.js", line: 544, side: SideNew,
+			wantLine: 544, wantType: SegmentContext, wantFile: FileTypeTo,
+		},
+		{
+			name: "removed line on the old side",
+			path: "src/app.js", line: 542, side: SideOld,
+			wantLine: 542, wantType: SegmentRemoved, wantFile: FileTypeFrom,
+		},
+		{
+			name: "context line on the old side",
+			path: "src/app.js", line: 540, side: SideOld,
+			wantLine: 540, wantType: SegmentContext, wantFile: FileTypeFrom,
+		},
+		{
+			name: "renamed file keeps the source path",
+			path: "src/new/toolbar.vue", line: 10, side: SideNew,
+			wantLine: 10, wantType: SegmentAdded, wantFile: FileTypeTo,
+			wantSrc: "src/old/toolbar.vue",
+		},
+		{
+			name: "renamed file is also found by its old path",
+			path: "src/old/toolbar.vue", line: 10, side: SideNew,
+			wantLine: 10, wantType: SegmentAdded, wantFile: FileTypeTo,
+			wantSrc: "src/old/toolbar.vue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			anchor, err := diff.ResolveLineAnchor(tt.path, tt.line, tt.side)
+			if err != nil {
+				t.Fatalf("ResolveLineAnchor returned error: %v", err)
+			}
+			if anchor.Line != tt.wantLine {
+				t.Errorf("line = %d, want %d", anchor.Line, tt.wantLine)
+			}
+			if anchor.LineType != tt.wantType {
+				t.Errorf("lineType = %q, want %q", anchor.LineType, tt.wantType)
+			}
+			if anchor.FileType != tt.wantFile {
+				t.Errorf("fileType = %q, want %q", anchor.FileType, tt.wantFile)
+			}
+			if anchor.SrcPath != tt.wantSrc {
+				t.Errorf("srcPath = %q, want %q", anchor.SrcPath, tt.wantSrc)
+			}
+			if anchor.DiffType != DiffTypeEffective {
+				t.Errorf("diffType = %q, want %q", anchor.DiffType, DiffTypeEffective)
+			}
+			if anchor.FromHash != "aaa111base" || anchor.ToHash != "bbb222head" {
+				t.Errorf("hashes = %q/%q, want the diff's own hashes", anchor.FromHash, anchor.ToHash)
+			}
+		})
+	}
+}
+
+func TestResolveLineAnchorRenamedFileUsesDestinationPath(t *testing.T) {
+	anchor, err := testDiff(t).ResolveLineAnchor("src/old/toolbar.vue", 10, SideNew)
+	if err != nil {
+		t.Fatalf("ResolveLineAnchor returned error: %v", err)
+	}
+
+	if anchor.Path != "src/new/toolbar.vue" {
+		t.Errorf("path = %q, want the destination path", anchor.Path)
+	}
+}
+
+func TestResolveLineAnchorRejectsWrongSide(t *testing.T) {
+	// Bitbucket fills in a source line number for added lines too, so an
+	// old-side lookup must ignore ADDED segments rather than match them: the
+	// old file ends at line 543.
+	_, err := testDiff(t).ResolveLineAnchor("src/app.js", 544, SideOld)
+
+	var lineErr *ErrLineNotInDiff
+	if !errors.As(err, &lineErr) {
+		t.Fatalf("error = %v, want ErrLineNotInDiff", err)
+	}
+	if !strings.Contains(lineErr.Error(), "540-543") {
+		t.Errorf("error %q does not report the commentable source range", lineErr.Error())
+	}
+}
+
+func TestResolveLineAnchorLineOutsideDiff(t *testing.T) {
+	_, err := testDiff(t).ResolveLineAnchor("src/app.js", 9000, SideNew)
+
+	var lineErr *ErrLineNotInDiff
+	if !errors.As(err, &lineErr) {
+		t.Fatalf("error = %v, want ErrLineNotInDiff", err)
+	}
+	if !strings.Contains(lineErr.Error(), "540-544") {
+		t.Errorf("error %q does not report the commentable destination range", lineErr.Error())
+	}
+}
+
+func TestResolveLineAnchorUnknownPath(t *testing.T) {
+	_, err := testDiff(t).ResolveLineAnchor("src/untouched.js", 1, SideNew)
+
+	var pathErr *ErrPathNotInDiff
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("error = %v, want ErrPathNotInDiff", err)
+	}
+	if !strings.Contains(pathErr.Error(), "src/app.js") {
+		t.Errorf("error %q does not list the changed files", pathErr.Error())
+	}
+}
+
+func TestResolveFileAnchorHasNoLine(t *testing.T) {
+	anchor, err := testDiff(t).ResolveFileAnchor("src/app.js")
+	if err != nil {
+		t.Fatalf("ResolveFileAnchor returned error: %v", err)
+	}
+
+	if anchor.Line != 0 || anchor.LineType != "" || anchor.FileType != "" {
+		t.Errorf("file anchor carries line data: %+v", anchor)
+	}
+}
+
+func TestParseDiffSide(t *testing.T) {
+	tests := map[string]DiffSide{
+		"":            SideNew,
+		"new":         SideNew,
+		"TO":          SideNew,
+		"destination": SideNew,
+		"old":         SideOld,
+		"from":        SideOld,
+		"source":      SideOld,
+	}
+
+	for in, want := range tests {
+		got, err := ParseDiffSide(in)
+		if err != nil {
+			t.Fatalf("ParseDiffSide(%q) returned error: %v", in, err)
+		}
+		if got != want {
+			t.Errorf("ParseDiffSide(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	if _, err := ParseDiffSide("sideways"); err == nil {
+		t.Error("ParseDiffSide accepted an invalid side")
+	}
+}
+
+func TestGetPullRequestDiffJSONRequestsContextLines(t *testing.T) {
+	var gotPath, gotContext, gotAccept string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotContext = r.URL.Query().Get("contextLines")
+		gotAccept = r.Header.Get("Accept")
+		_, _ = w.Write([]byte(diffFixture))
+	}))
+	defer server.Close()
+
+	client := NewBitbucketClient(server.URL, "tester", "token")
+	client.HTTPClient = server.Client()
+
+	diff, err := client.GetPullRequestDiffJSON(context.Background(), "MYPROJ", "myrepo", 140, 10)
+	if err != nil {
+		t.Fatalf("GetPullRequestDiffJSON returned error: %v", err)
+	}
+
+	wantPath := "/rest/api/1.0/projects/MYPROJ/repos/myrepo/pull-requests/140/diff"
+	if gotPath != wantPath {
+		t.Errorf("path = %q, want %q", gotPath, wantPath)
+	}
+	if gotContext != "10" {
+		t.Errorf("contextLines = %q, want 10", gotContext)
+	}
+	if gotAccept != "application/json" {
+		t.Errorf("Accept = %q, want application/json", gotAccept)
+	}
+	if len(diff.Diffs) != 2 {
+		t.Errorf("decoded %d file diffs, want 2", len(diff.Diffs))
+	}
+}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -267,58 +267,11 @@ var prDiffCmd = &cobra.Command{
 	},
 }
 
-var prCommentCmd = &cobra.Command{
-	Use:   "comment [project/repo] [pr-id] [text]",
-	Short: "Add a comment to a pull request",
-	Args:  cobra.RangeArgs(2, 3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-		var project, repo string
-		var prIDStr, text string
-
-		if len(args) == 3 {
-			var err error
-			project, repo, err = parseRepoArg(args[0])
-			if err != nil {
-				return err
-			}
-			prIDStr = args[1]
-			text = args[2]
-		} else {
-			var err error
-			project, repo, err = parseRepoArg("")
-			if err != nil {
-				return fmt.Errorf("PR ID and text required: %w", err)
-			}
-			prIDStr = args[0]
-			text = args[1]
-		}
-
-		prID, err := strconv.Atoi(prIDStr)
-		if err != nil {
-			return fmt.Errorf("invalid PR ID: %v", err)
-		}
-
-		client, err := getClient()
-		if err != nil {
-			return err
-		}
-		comment, err := client.AddPullRequestComment(ctx, project, repo, prID, text)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Comment added (ID: %d)\n", comment.ID)
-		return nil
-	},
-}
-
 func init() {
 	rootCmd.AddCommand(prCmd)
 	prCmd.AddCommand(prListCmd)
 	prCmd.AddCommand(prViewCmd)
 	prCmd.AddCommand(prDiffCmd)
-	prCmd.AddCommand(prCommentCmd)
 
 	prListCmd.Flags().String("state", "OPEN", "Filter by state (OPEN, MERGED, DECLINED, ALL)")
 	prListCmd.Flags().Int("limit", cmdutil.DefaultLimit, "Maximum number of results")

--- a/cmd/pr_comment.go
+++ b/cmd/pr_comment.go
@@ -210,7 +210,11 @@ their surrounding context) can be anchored.`,
 
   # Post a whole review from JSON, checking the anchors first
   atl pr comment MYPROJ/myrepo 140 --batch findings.json --dry-run
-  atl pr comment MYPROJ/myrepo 140 --batch findings.json`,
+  atl pr comment MYPROJ/myrepo 140 --batch findings.json
+
+  # Correct or remove an existing comment (yours; pending or published)
+  atl pr comment MYPROJ/myrepo 140 --edit 331 -b "corrected text"
+  atl pr comment MYPROJ/myrepo 140 --delete 331`,
 	Args: cobra.RangeArgs(1, 3),
 	RunE: runPRComment,
 }
@@ -221,6 +225,13 @@ func runPRComment(cmd *cobra.Command, args []string) error {
 	project, repo, prID, rest, err := parsePRArgs(args)
 	if err != nil {
 		return err
+	}
+
+	if editID, _ := cmd.Flags().GetInt("edit"); editID != 0 {
+		return runPRCommentEdit(cmd, project, repo, prID, editID, rest)
+	}
+	if deleteID, _ := cmd.Flags().GetInt("delete"); deleteID != 0 {
+		return runPRCommentDelete(cmd, project, repo, prID, deleteID, rest)
 	}
 
 	batchFile, _ := cmd.Flags().GetString("batch")
@@ -274,6 +285,77 @@ func runPRComment(cmd *cobra.Command, args []string) error {
 		return json.NewEncoder(os.Stdout).Encode(posted)
 	}
 
+	return nil
+}
+
+// lifecycleFlagConflict reports the first anchor/review flag that makes no
+// sense when editing or deleting an existing comment.
+func lifecycleFlagConflict(cmd *cobra.Command, action string, extra ...string) error {
+	conflicting := append([]string{"file", "line", "side", "reply", "blocker", "pending", "batch", "dry-run", "line-type", "file-type"}, extra...)
+	for _, flag := range conflicting {
+		if cmd.Flags().Changed(flag) {
+			return fmt.Errorf("--%s cannot be combined with --%s: %s targets an existing comment", flag, action, action)
+		}
+	}
+	return nil
+}
+
+func runPRCommentEdit(cmd *cobra.Command, project, repo string, prID, commentID int, positionalText string) error {
+	ctx := cmd.Context()
+
+	if err := lifecycleFlagConflict(cmd, "edit", "delete"); err != nil {
+		return err
+	}
+	body, err := resolveCommentBody(cmd, positionalText)
+	if err != nil {
+		return err
+	}
+
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	current, err := client.GetPullRequestComment(ctx, project, repo, prID, commentID)
+	if err != nil {
+		return fmt.Errorf("fetching comment %d: %w", commentID, err)
+	}
+	updated, err := client.UpdatePullRequestComment(ctx, project, repo, prID, commentID, current.Version, body)
+	if err != nil {
+		return fmt.Errorf("updating comment %d: %w", commentID, err)
+	}
+
+	if jsonOutput, _ := cmd.Flags().GetBool("json"); jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(updated)
+	}
+	fmt.Printf("✓ Updated comment %d (v%d -> v%d)\n", updated.ID, current.Version, updated.Version)
+	return nil
+}
+
+func runPRCommentDelete(cmd *cobra.Command, project, repo string, prID, commentID int, positionalText string) error {
+	ctx := cmd.Context()
+
+	if err := lifecycleFlagConflict(cmd, "delete", "body", "body-file", "edit"); err != nil {
+		return err
+	}
+	if positionalText != "" {
+		return errors.New("--delete takes no comment text")
+	}
+
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	current, err := client.GetPullRequestComment(ctx, project, repo, prID, commentID)
+	if err != nil {
+		return fmt.Errorf("fetching comment %d: %w", commentID, err)
+	}
+	if err := client.DeletePullRequestComment(ctx, project, repo, prID, commentID, current.Version); err != nil {
+		return fmt.Errorf("deleting comment %d: %w", commentID, err)
+	}
+
+	fmt.Printf("✓ Deleted comment %d\n", commentID)
 	return nil
 }
 
@@ -715,6 +797,8 @@ func init() {
 	prCommentCmd.Flags().Bool("json", false, "Output created comments as JSON")
 	prCommentCmd.Flags().String("line-type", "", "Override the resolved line type (ADDED, REMOVED, CONTEXT)")
 	prCommentCmd.Flags().String("file-type", "", "Override the resolved file side (TO, FROM)")
+	prCommentCmd.Flags().Int("edit", 0, "Replace the text of an existing comment ID")
+	prCommentCmd.Flags().Int("delete", 0, "Delete an existing comment ID")
 
 	prCommentsCmd.Flags().StringP("file", "f", "", "Only show comments anchored to paths containing this string")
 	prCommentsCmd.Flags().Int("limit", cmdutil.DefaultActivityLimit, "Maximum number of activities to scan")

--- a/cmd/pr_comment.go
+++ b/cmd/pr_comment.go
@@ -1,0 +1,723 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lroolle/atlas-cli/api"
+	"github.com/lroolle/atlas-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// Context lines requested when resolving an anchor. The first value matches
+// what the Bitbucket diff view shows; the second is a fallback for lines
+// further away from a change.
+const (
+	anchorContextLines     = 10
+	anchorWideContextLines = 500
+)
+
+// commentSpec describes one comment to post. It is both the internal
+// representation of the flags and the schema of --batch entries.
+type commentSpec struct {
+	Body     string `json:"body"`
+	File     string `json:"file,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Side     string `json:"side,omitempty"`
+	ReplyTo  int    `json:"reply_to,omitempty"`
+	Blocker  bool   `json:"blocker,omitempty"`
+	Pending  bool   `json:"pending,omitempty"`
+	LineType string `json:"line_type,omitempty"`
+	FileType string `json:"file_type,omitempty"`
+}
+
+func (s *commentSpec) validate() error {
+	if strings.TrimSpace(s.Body) == "" {
+		return errors.New("body required")
+	}
+	if s.ReplyTo != 0 && (s.File != "" || s.Line != 0) {
+		return errors.New("--reply cannot be combined with --file/--line: a reply inherits its parent's anchor")
+	}
+	if s.Line != 0 && s.File == "" {
+		return errors.New("--line requires --file")
+	}
+	if s.Line < 0 {
+		return fmt.Errorf("invalid line %d", s.Line)
+	}
+	if _, err := api.ParseDiffSide(s.Side); err != nil {
+		return err
+	}
+	if err := validateEnum("line-type", s.LineType, api.SegmentAdded, api.SegmentRemoved, api.SegmentContext); err != nil {
+		return err
+	}
+	return validateEnum("file-type", s.FileType, api.FileTypeTo, api.FileTypeFrom)
+}
+
+func validateEnum(name, value string, allowed ...string) error {
+	if value == "" {
+		return nil
+	}
+	for _, a := range allowed {
+		if strings.EqualFold(value, a) {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid --%s %q: use one of %s", name, value, strings.Join(allowed, ", "))
+}
+
+// hasManualAnchor reports whether the caller pinned down the anchor themselves,
+// in which case the diff does not have to resolve it.
+func (s *commentSpec) hasManualAnchor() bool {
+	return s.LineType != "" && s.FileType != ""
+}
+
+func (s *commentSpec) request(anchor *api.CommentAnchor) api.CommentRequest {
+	req := api.CommentRequest{Text: s.Body, Anchor: anchor}
+	if s.ReplyTo != 0 {
+		req.Parent = &api.CommentParent{ID: s.ReplyTo}
+	}
+	if s.Blocker {
+		req.Severity = api.SeverityBlocker
+	}
+	if s.Pending {
+		req.State = api.CommentStatePending
+	}
+	return req
+}
+
+// anchorResolver turns file/line references into Bitbucket anchors, fetching
+// the pull request diff at most twice regardless of how many comments it
+// resolves.
+type anchorResolver struct {
+	client  *api.BitbucketClient
+	project string
+	repo    string
+	prID    int
+
+	diff       *api.Diff
+	diffIsWide bool
+}
+
+func (r *anchorResolver) getDiff(ctx context.Context, wide bool) (*api.Diff, error) {
+	if r.diff != nil && (r.diffIsWide || !wide) {
+		return r.diff, nil
+	}
+
+	contextLines := anchorContextLines
+	if wide {
+		contextLines = anchorWideContextLines
+	}
+
+	diff, err := r.client.GetPullRequestDiffJSON(ctx, r.project, r.repo, r.prID, contextLines)
+	if err != nil {
+		return nil, fmt.Errorf("fetching diff: %w", err)
+	}
+
+	r.diff, r.diffIsWide = diff, wide
+	return diff, nil
+}
+
+func (r *anchorResolver) resolve(ctx context.Context, spec commentSpec) (*api.CommentAnchor, error) {
+	if spec.File == "" {
+		return nil, nil
+	}
+
+	side, err := api.ParseDiffSide(spec.Side)
+	if err != nil {
+		return nil, err
+	}
+
+	diff, err := r.getDiff(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+
+	anchor, err := resolveAnchor(diff, spec, side)
+
+	// A line outside the default diff context may still be commentable; widen
+	// the context once before giving up.
+	var lineErr *api.ErrLineNotInDiff
+	if errors.As(err, &lineErr) && !r.diffIsWide {
+		wideDiff, wideErr := r.getDiff(ctx, true)
+		if wideErr != nil {
+			return nil, wideErr
+		}
+		anchor, err = resolveAnchor(wideDiff, spec, side)
+	}
+
+	if err != nil {
+		if !spec.hasManualAnchor() {
+			return nil, err
+		}
+		anchor = &api.CommentAnchor{
+			DiffType: api.DiffTypeEffective,
+			Path:     spec.File,
+			Line:     spec.Line,
+			FromHash: diff.FromHash,
+			ToHash:   diff.ToHash,
+		}
+	}
+
+	if spec.LineType != "" {
+		anchor.LineType = strings.ToUpper(spec.LineType)
+	}
+	if spec.FileType != "" {
+		anchor.FileType = strings.ToUpper(spec.FileType)
+	}
+
+	return anchor, nil
+}
+
+func resolveAnchor(diff *api.Diff, spec commentSpec, side api.DiffSide) (*api.CommentAnchor, error) {
+	if spec.Line == 0 {
+		return diff.ResolveFileAnchor(spec.File)
+	}
+	return diff.ResolveLineAnchor(spec.File, spec.Line, side)
+}
+
+var prCommentCmd = &cobra.Command{
+	Use:   "comment [project/repo] <pr-id> [text]",
+	Short: "Comment on a pull request, optionally on a specific line",
+	Long: `Add a comment to a pull request.
+
+Without --file the comment lands on the pull request itself. With --file and
+--line it is anchored to that line of the diff, the way inline review comments
+are in the web UI. The line type (ADDED/REMOVED/CONTEXT) is resolved from the
+diff, so only a path and a line number are needed.
+
+--line refers to the line in the new file; use --side old to comment on a line
+that the pull request deletes. Only lines the diff touches (changed lines and
+their surrounding context) can be anchored.`,
+	Example: `  # General comment
+  atl pr comment MYPROJ/myrepo 140 "LGTM"
+
+  # Inline comment on a line of the new file
+  atl pr comment MYPROJ/myrepo 140 -f src/app.js -L 543 -b "this allocation leaks"
+
+  # Comment on a deleted line, as a blocker task
+  atl pr comment MYPROJ/myrepo 140 -f src/app.js -L 120 --side old --blocker -b "why drop this?"
+
+  # Reply to an existing comment
+  atl pr comment MYPROJ/myrepo 140 --reply 331 -b "fixed in a1b2c3d"
+
+  # Post a whole review from JSON, checking the anchors first
+  atl pr comment MYPROJ/myrepo 140 --batch findings.json --dry-run
+  atl pr comment MYPROJ/myrepo 140 --batch findings.json`,
+	Args: cobra.RangeArgs(1, 3),
+	RunE: runPRComment,
+}
+
+func runPRComment(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	project, repo, prID, rest, err := parsePRArgs(args)
+	if err != nil {
+		return err
+	}
+
+	batchFile, _ := cmd.Flags().GetString("batch")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+
+	specs, err := collectSpecs(cmd, rest, batchFile)
+	if err != nil {
+		return err
+	}
+
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	resolver := &anchorResolver{client: client, project: project, repo: repo, prID: prID}
+
+	// Resolve every anchor before posting anything, so a bad path or line in
+	// one entry does not leave a batch half-posted.
+	anchors := make([]*api.CommentAnchor, len(specs))
+	for i, spec := range specs {
+		anchor, err := resolver.resolve(ctx, spec)
+		if err != nil {
+			return fmt.Errorf("comment %d/%d: %w", i+1, len(specs), err)
+		}
+		anchors[i] = anchor
+	}
+
+	if dryRun {
+		return printCommentDryRun(prID, specs, anchors)
+	}
+
+	posted := make([]*api.Comment, 0, len(specs))
+	for i, spec := range specs {
+		comment, err := client.CreatePullRequestComment(ctx, project, repo, prID, spec.request(anchors[i]))
+		if err != nil {
+			if len(posted) > 0 {
+				fmt.Fprintf(os.Stderr, "posted %d of %d comments before failing\n", len(posted), len(specs))
+			}
+			return fmt.Errorf("comment %d/%d: %w", i+1, len(specs), err)
+		}
+		posted = append(posted, comment)
+
+		if !jsonOutput {
+			fmt.Printf("✓ %s (ID: %d)\n", describeTarget(spec, anchors[i]), comment.ID)
+		}
+	}
+
+	if jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(posted)
+	}
+
+	return nil
+}
+
+// collectSpecs builds the comment list from either --batch or the flags and
+// positional text.
+func collectSpecs(cmd *cobra.Command, positionalText, batchFile string) ([]commentSpec, error) {
+	if batchFile != "" {
+		if positionalText != "" {
+			return nil, errors.New("--batch carries its own comments: drop the comment text argument")
+		}
+		for _, flag := range []string{"body", "body-file", "file", "line", "side", "reply", "blocker", "line-type", "file-type"} {
+			if cmd.Flags().Changed(flag) {
+				return nil, fmt.Errorf("--batch carries its own comments: --%s belongs in the batch entries", flag)
+			}
+		}
+
+		specs, err := readBatch(batchFile)
+		if err != nil {
+			return nil, err
+		}
+
+		// Drafting is a property of the whole review, so the flag overrides
+		// what the batch file says.
+		if pending, _ := cmd.Flags().GetBool("pending"); pending {
+			for i := range specs {
+				specs[i].Pending = true
+			}
+		}
+
+		return specs, nil
+	}
+
+	body, err := resolveCommentBody(cmd, positionalText)
+	if err != nil {
+		return nil, err
+	}
+
+	spec := commentSpec{Body: body}
+	spec.File, _ = cmd.Flags().GetString("file")
+	spec.Line, _ = cmd.Flags().GetInt("line")
+	spec.Side, _ = cmd.Flags().GetString("side")
+	spec.ReplyTo, _ = cmd.Flags().GetInt("reply")
+	spec.Blocker, _ = cmd.Flags().GetBool("blocker")
+	spec.Pending, _ = cmd.Flags().GetBool("pending")
+	spec.LineType, _ = cmd.Flags().GetString("line-type")
+	spec.FileType, _ = cmd.Flags().GetString("file-type")
+
+	if err := spec.validate(); err != nil {
+		return nil, err
+	}
+
+	return []commentSpec{spec}, nil
+}
+
+func resolveCommentBody(cmd *cobra.Command, positionalText string) (string, error) {
+	body, _ := cmd.Flags().GetString("body")
+	bodyFile, _ := cmd.Flags().GetString("body-file")
+
+	set := 0
+	for _, v := range []string{positionalText, body, bodyFile} {
+		if v != "" {
+			set++
+		}
+	}
+	if set > 1 {
+		return "", errors.New("provide comment text once: as an argument, --body or --body-file")
+	}
+
+	if bodyFile != "" {
+		data, err := readFileOrStdin(bodyFile)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimRight(string(data), "\n"), nil
+	}
+
+	if body != "" {
+		return body, nil
+	}
+	if positionalText != "" {
+		return positionalText, nil
+	}
+
+	return "", errors.New("comment text required: pass it as an argument, --body or --body-file")
+}
+
+func readBatch(path string) ([]commentSpec, error) {
+	data, err := readFileOrStdin(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var specs []commentSpec
+	if err := json.Unmarshal(data, &specs); err != nil {
+		return nil, fmt.Errorf("parsing batch %s: %w (expected a JSON array of {body, file, line, side, reply_to, blocker, pending})", path, err)
+	}
+	if len(specs) == 0 {
+		return nil, fmt.Errorf("batch %s contains no comments", path)
+	}
+
+	for i := range specs {
+		if err := specs[i].validate(); err != nil {
+			return nil, fmt.Errorf("batch entry %d: %w", i+1, err)
+		}
+	}
+
+	return specs, nil
+}
+
+func readFileOrStdin(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return data, nil
+}
+
+func printCommentDryRun(prID int, specs []commentSpec, anchors []*api.CommentAnchor) error {
+	fmt.Printf("Would post %d comment(s) on PR #%d:\n", len(specs), prID)
+	for i, spec := range specs {
+		fmt.Printf("\n%d. %s\n", i+1, describeTarget(spec, anchors[i]))
+		for _, line := range strings.Split(spec.Body, "\n") {
+			fmt.Printf("   | %s\n", line)
+		}
+	}
+	return nil
+}
+
+func describeTarget(spec commentSpec, anchor *api.CommentAnchor) string {
+	var target string
+	switch {
+	case spec.ReplyTo != 0:
+		target = fmt.Sprintf("reply to comment #%d", spec.ReplyTo)
+	case anchor == nil:
+		target = "pull request comment"
+	case anchor.Line == 0:
+		target = fmt.Sprintf("file comment on %s", anchor.Path)
+	default:
+		target = fmt.Sprintf("%s:%d [%s/%s]", anchor.Path, anchor.Line, anchor.LineType, anchor.FileType)
+	}
+
+	if spec.Blocker {
+		target += " [task]"
+	}
+	if spec.Pending {
+		target += " [pending]"
+	}
+	return target
+}
+
+var prCommentsCmd = &cobra.Command{
+	Use:     "comments [project/repo] <pr-id>",
+	Short:   "List comments on a pull request, grouped by file and line",
+	Aliases: []string{"reviews"},
+	Long: `List the comments on a pull request.
+
+Comments are grouped by what they are anchored to: general pull request
+comments first, then each file and line. Comment IDs shown here are what
+'atl pr comment --reply' takes.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runPRComments,
+}
+
+// commentEntry is a comment plus where it sits in the review.
+type commentEntry struct {
+	Comment api.Comment        `json:"comment"`
+	Anchor  *api.CommentAnchor `json:"anchor,omitempty"`
+	Depth   int                `json:"depth"`
+}
+
+func runPRComments(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	project, repo, prID, _, err := parsePRArgs(args)
+	if err != nil {
+		return err
+	}
+
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	limit, _ := cmd.Flags().GetInt("limit")
+	fileFilter, _ := cmd.Flags().GetString("file")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	pending, _ := cmd.Flags().GetBool("pending")
+
+	var entries []commentEntry
+	if pending {
+		comments, err := client.GetPendingReview(ctx, project, repo, prID, limit)
+		if err != nil {
+			return fmt.Errorf("fetching pending review: %w", err)
+		}
+		for _, c := range comments {
+			entries = appendCommentTree(entries, c, nil, 0)
+		}
+		sortCommentEntries(entries)
+	} else {
+		activities, err := client.GetPullRequestActivity(ctx, project, repo, prID, limit)
+		if err != nil {
+			return fmt.Errorf("fetching comments: %w", err)
+		}
+		entries = commentsFromActivities(activities)
+	}
+
+	if fileFilter != "" {
+		entries = filterEntriesByFile(entries, fileFilter)
+	}
+
+	if jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(entries)
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No comments found")
+		return nil
+	}
+
+	printCommentEntries(entries)
+	return nil
+}
+
+// commentsFromActivities flattens the activity feed into comment threads. The
+// feed reports replies both nested under their parent and as activities of
+// their own, so nested IDs win and the duplicates are dropped.
+func commentsFromActivities(activities []api.Activity) []commentEntry {
+	nested := map[int]bool{}
+	for _, a := range activities {
+		if a.Comment != nil {
+			markNested(nested, *a.Comment)
+		}
+	}
+
+	var entries []commentEntry
+	seen := map[int]bool{}
+	for _, a := range activities {
+		if a.Comment == nil || nested[a.Comment.ID] || seen[a.Comment.ID] {
+			continue
+		}
+		seen[a.Comment.ID] = true
+		entries = appendCommentTree(entries, *a.Comment, a.CommentAnchor, 0)
+	}
+
+	sortCommentEntries(entries)
+	return entries
+}
+
+func markNested(nested map[int]bool, c api.Comment) {
+	for _, reply := range c.Comments {
+		nested[reply.ID] = true
+		markNested(nested, reply)
+	}
+}
+
+func appendCommentTree(entries []commentEntry, c api.Comment, anchor *api.CommentAnchor, depth int) []commentEntry {
+	if anchor == nil {
+		anchor = c.Anchor
+	}
+
+	replies := c.Comments
+	c.Comments = nil
+	entries = append(entries, commentEntry{Comment: c, Anchor: anchor, Depth: depth})
+
+	for _, reply := range replies {
+		entries = appendCommentTree(entries, reply, anchor, depth+1)
+	}
+	return entries
+}
+
+// sortCommentEntries orders threads by location: general comments first, then
+// by path and line. Replies keep their position under their root comment.
+func sortCommentEntries(entries []commentEntry) {
+	type thread struct {
+		entries []commentEntry
+		path    string
+		line    int
+		created int64
+	}
+
+	var threads []thread
+	for _, e := range entries {
+		if e.Depth == 0 {
+			t := thread{created: e.Comment.CreatedDate}
+			if e.Anchor != nil {
+				t.path, t.line = e.Anchor.Path, e.Anchor.Line
+			}
+			threads = append(threads, t)
+		}
+		if len(threads) == 0 {
+			continue
+		}
+		threads[len(threads)-1].entries = append(threads[len(threads)-1].entries, e)
+	}
+
+	sort.SliceStable(threads, func(i, j int) bool {
+		a, b := threads[i], threads[j]
+		if (a.path == "") != (b.path == "") {
+			return a.path == ""
+		}
+		if a.path != b.path {
+			return a.path < b.path
+		}
+		if a.line != b.line {
+			return a.line < b.line
+		}
+		return a.created < b.created
+	})
+
+	i := 0
+	for _, t := range threads {
+		for _, e := range t.entries {
+			entries[i] = e
+			i++
+		}
+	}
+}
+
+func filterEntriesByFile(entries []commentEntry, file string) []commentEntry {
+	var filtered []commentEntry
+	keep := false
+	for _, e := range entries {
+		if e.Depth == 0 {
+			keep = e.Anchor != nil && strings.Contains(e.Anchor.Path, file)
+		}
+		if keep {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+func printCommentEntries(entries []commentEntry) {
+	lastGroup := "\x00"
+
+	for _, e := range entries {
+		if e.Depth == 0 {
+			if group := commentGroup(e.Anchor); group != lastGroup {
+				if lastGroup != "\x00" {
+					fmt.Println()
+				}
+				fmt.Println(group)
+				lastGroup = group
+			}
+		}
+
+		indent := strings.Repeat("  ", e.Depth+1)
+		date := time.Unix(e.Comment.CreatedDate/1000, 0).Format("2006-01-02 15:04")
+		fmt.Printf("%s#%d  %s  %s%s\n", indent, e.Comment.ID, e.Comment.Author.Name, date, commentMarkers(e))
+
+		for _, line := range strings.Split(strings.TrimRight(e.Comment.Text, "\n"), "\n") {
+			fmt.Printf("%s  %s\n", indent, line)
+		}
+	}
+}
+
+func commentGroup(anchor *api.CommentAnchor) string {
+	if anchor == nil || anchor.Path == "" {
+		return "General"
+	}
+	group := anchor.Location()
+	if anchor.LineType != "" {
+		group += "  [" + anchor.LineType + "]"
+	}
+	return group
+}
+
+func commentMarkers(e commentEntry) string {
+	var markers []string
+	if e.Comment.Severity == api.SeverityBlocker {
+		markers = append(markers, "TASK")
+	}
+	if state := e.Comment.State; state != "" && state != api.CommentStateOpen {
+		markers = append(markers, state)
+	}
+	if e.Anchor != nil && e.Anchor.Orphaned {
+		markers = append(markers, "ORPHANED")
+	}
+	if len(markers) == 0 {
+		return ""
+	}
+	return "  [" + strings.Join(markers, "] [") + "]"
+}
+
+// parsePRArgs handles the shared [project/repo] <pr-id> [text] argument shape.
+func parsePRArgs(args []string) (project, repo string, prID int, rest string, err error) {
+	var prIDStr string
+
+	if len(args) > 1 && !isNumeric(args[0]) {
+		project, repo, err = parseRepoArg(args[0])
+		if err != nil {
+			return "", "", 0, "", err
+		}
+		prIDStr = args[1]
+		if len(args) > 2 {
+			rest = args[2]
+		}
+	} else {
+		project, repo, err = parseRepoArg("")
+		if err != nil {
+			return "", "", 0, "", fmt.Errorf("PR ID required: %w", err)
+		}
+		prIDStr = args[0]
+		if len(args) > 1 {
+			rest = args[1]
+		}
+	}
+
+	prID, err = strconv.Atoi(prIDStr)
+	if err != nil {
+		return "", "", 0, "", fmt.Errorf("invalid PR ID: %q", prIDStr)
+	}
+
+	return project, repo, prID, rest, nil
+}
+
+func isNumeric(s string) bool {
+	_, err := strconv.Atoi(s)
+	return err == nil
+}
+
+func init() {
+	prCmd.AddCommand(prCommentCmd)
+	prCmd.AddCommand(prCommentsCmd)
+
+	prCommentCmd.Flags().StringP("body", "b", "", "Comment text")
+	prCommentCmd.Flags().StringP("body-file", "F", "", "Read comment text from file ('-' for stdin)")
+	prCommentCmd.Flags().StringP("file", "f", "", "Anchor the comment to this file of the diff")
+	prCommentCmd.Flags().IntP("line", "L", 0, "Anchor the comment to this line (requires --file)")
+	prCommentCmd.Flags().String("side", "new", "Which side --line refers to: new or old")
+	prCommentCmd.Flags().Int("reply", 0, "Reply to an existing comment ID")
+	prCommentCmd.Flags().Bool("blocker", false, "Post as a task that blocks the merge")
+	prCommentCmd.Flags().Bool("pending", false, "Keep as an unpublished review comment")
+	prCommentCmd.Flags().String("batch", "", "Post multiple comments from a JSON file ('-' for stdin)")
+	prCommentCmd.Flags().Bool("dry-run", false, "Resolve anchors and print what would be posted")
+	prCommentCmd.Flags().Bool("json", false, "Output created comments as JSON")
+	prCommentCmd.Flags().String("line-type", "", "Override the resolved line type (ADDED, REMOVED, CONTEXT)")
+	prCommentCmd.Flags().String("file-type", "", "Override the resolved file side (TO, FROM)")
+
+	prCommentsCmd.Flags().StringP("file", "f", "", "Only show comments anchored to paths containing this string")
+	prCommentsCmd.Flags().Int("limit", cmdutil.DefaultActivityLimit, "Maximum number of activities to scan")
+	prCommentsCmd.Flags().Bool("pending", false, "Show your unpublished review comments instead")
+	prCommentsCmd.Flags().Bool("json", false, "Output as JSON")
+}

--- a/cmd/pr_comment_test.go
+++ b/cmd/pr_comment_test.go
@@ -315,3 +315,23 @@ func TestDescribeTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestLifecycleFlagConflict(t *testing.T) {
+	cmd := prCommentCmd
+	t.Cleanup(func() {
+		_ = cmd.Flags().Set("file", "")
+		cmd.Flags().Lookup("file").Changed = false
+	})
+
+	if err := lifecycleFlagConflict(cmd, "edit", "delete"); err != nil {
+		t.Fatalf("no flags set, got error: %v", err)
+	}
+
+	if err := cmd.Flags().Set("file", "src/app.py"); err != nil {
+		t.Fatalf("setting flag: %v", err)
+	}
+	err := lifecycleFlagConflict(cmd, "edit", "delete")
+	if err == nil || !strings.Contains(err.Error(), "--file cannot be combined with --edit") {
+		t.Fatalf("expected --file/--edit conflict, got: %v", err)
+	}
+}

--- a/cmd/pr_comment_test.go
+++ b/cmd/pr_comment_test.go
@@ -1,0 +1,317 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lroolle/atlas-cli/api"
+)
+
+func TestCommentSpecValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    commentSpec
+		wantErr string
+	}{
+		{
+			name: "line comment",
+			spec: commentSpec{Body: "x", File: "a.js", Line: 10},
+		},
+		{
+			name: "file comment",
+			spec: commentSpec{Body: "x", File: "a.js"},
+		},
+		{
+			name: "general comment",
+			spec: commentSpec{Body: "x"},
+		},
+		{
+			name:    "empty body",
+			spec:    commentSpec{Body: "  "},
+			wantErr: "body required",
+		},
+		{
+			name:    "anchored reply",
+			spec:    commentSpec{Body: "x", ReplyTo: 5, File: "a.js", Line: 10},
+			wantErr: "inherits its parent's anchor",
+		},
+		{
+			name:    "line without file",
+			spec:    commentSpec{Body: "x", Line: 10},
+			wantErr: "--line requires --file",
+		},
+		{
+			name:    "unknown side",
+			spec:    commentSpec{Body: "x", File: "a.js", Line: 10, Side: "middle"},
+			wantErr: "invalid side",
+		},
+		{
+			name:    "unknown line type",
+			spec:    commentSpec{Body: "x", File: "a.js", Line: 10, LineType: "CHANGED"},
+			wantErr: "invalid --line-type",
+		},
+		{
+			name:    "unknown file type",
+			spec:    commentSpec{Body: "x", File: "a.js", Line: 10, FileType: "BOTH"},
+			wantErr: "invalid --file-type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate() returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validate() = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReadBatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "findings.json")
+	content := `[
+	  {"file": "src/app.js", "line": 543, "body": "this allocation leaks", "blocker": true},
+	  {"file": "src/app.js", "line": 120, "side": "old", "body": "why drop this?"},
+	  {"reply_to": 331, "body": "fixed"},
+	  {"body": "overall NAK"}
+	]`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing batch: %v", err)
+	}
+
+	specs, err := readBatch(path)
+	if err != nil {
+		t.Fatalf("readBatch returned error: %v", err)
+	}
+	if len(specs) != 4 {
+		t.Fatalf("parsed %d specs, want 4", len(specs))
+	}
+	if !specs[0].Blocker || specs[0].Line != 543 {
+		t.Errorf("first spec = %+v, want blocker on line 543", specs[0])
+	}
+	if specs[1].Side != "old" {
+		t.Errorf("second spec side = %q, want old", specs[1].Side)
+	}
+	if specs[2].ReplyTo != 331 {
+		t.Errorf("third spec reply_to = %d, want 331", specs[2].ReplyTo)
+	}
+}
+
+func TestReadBatchRejectsInvalidEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "findings.json")
+	if err := os.WriteFile(path, []byte(`[{"body":"ok"},{"file":"a.js","line":3}]`), 0o644); err != nil {
+		t.Fatalf("writing batch: %v", err)
+	}
+
+	_, err := readBatch(path)
+	if err == nil || !strings.Contains(err.Error(), "batch entry 2") {
+		t.Fatalf("error = %v, want it to name the bad entry", err)
+	}
+}
+
+func TestReadBatchRejectsEmptyList(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "findings.json")
+	if err := os.WriteFile(path, []byte(`[]`), 0o644); err != nil {
+		t.Fatalf("writing batch: %v", err)
+	}
+
+	if _, err := readBatch(path); err == nil {
+		t.Fatal("expected an error for an empty batch")
+	}
+}
+
+func TestCollectSpecsBatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "findings.json")
+	if err := os.WriteFile(path, []byte(`[{"body":"one"},{"body":"two","pending":false}]`), 0o644); err != nil {
+		t.Fatalf("writing batch: %v", err)
+	}
+
+	cmd := prCommentCmd
+	t.Cleanup(func() {
+		_ = cmd.Flags().Set("pending", "false")
+		cmd.Flags().Lookup("pending").Changed = false
+		_ = cmd.Flags().Set("file", "")
+		cmd.Flags().Lookup("file").Changed = false
+	})
+
+	// --pending is a property of the whole review, so it overrides the file.
+	if err := cmd.Flags().Set("pending", "true"); err != nil {
+		t.Fatalf("setting flag: %v", err)
+	}
+
+	specs, err := collectSpecs(cmd, "", path)
+	if err != nil {
+		t.Fatalf("collectSpecs returned error: %v", err)
+	}
+	if len(specs) != 2 || !specs[0].Pending || !specs[1].Pending {
+		t.Fatalf("specs = %+v, want both pending", specs)
+	}
+
+	// Per-comment flags belong in the batch entries, not on the command line.
+	if err := cmd.Flags().Set("file", "src/app.py"); err != nil {
+		t.Fatalf("setting flag: %v", err)
+	}
+	if _, err := collectSpecs(cmd, "", path); err == nil {
+		t.Error("expected an error for --batch combined with --file")
+	}
+}
+
+func TestCommentSpecRequest(t *testing.T) {
+	spec := commentSpec{Body: "x", Blocker: true, Pending: true}
+	anchor := &api.CommentAnchor{Path: "a.js", Line: 3}
+
+	req := spec.request(anchor)
+
+	if req.Severity != api.SeverityBlocker {
+		t.Errorf("severity = %q, want %q", req.Severity, api.SeverityBlocker)
+	}
+	if req.State != api.CommentStatePending {
+		t.Errorf("state = %q, want %q", req.State, api.CommentStatePending)
+	}
+	if req.Anchor != anchor {
+		t.Error("anchor not carried into the request")
+	}
+
+	replySpec := commentSpec{Body: "x", ReplyTo: 7}
+	reply := replySpec.request(nil)
+	if reply.Parent == nil || reply.Parent.ID != 7 {
+		t.Errorf("parent = %+v, want id 7", reply.Parent)
+	}
+	if reply.Severity != "" || reply.State != "" {
+		t.Errorf("plain reply carries severity %q / state %q", reply.Severity, reply.State)
+	}
+}
+
+func TestParsePRArgs(t *testing.T) {
+	project, repo, prID, rest, err := parsePRArgs([]string{"MYPROJ/myrepo", "140", "LGTM"})
+	if err != nil {
+		t.Fatalf("parsePRArgs returned error: %v", err)
+	}
+	if project != "MYPROJ" || repo != "myrepo" || prID != 140 || rest != "LGTM" {
+		t.Errorf("got %s/%s #%d %q", project, repo, prID, rest)
+	}
+
+	if _, _, _, _, err := parsePRArgs([]string{"MYPROJ/myrepo", "nine"}); err == nil {
+		t.Error("expected an error for a non-numeric PR ID")
+	}
+}
+
+func TestCommentsFromActivities(t *testing.T) {
+	reply := api.Comment{ID: 3, Text: "fixed", CreatedDate: 300}
+	anchored := api.Comment{ID: 2, Text: "peak leak", CreatedDate: 200, Comments: []api.Comment{reply}}
+	general := api.Comment{ID: 1, Text: "NAK", CreatedDate: 100}
+
+	activities := []api.Activity{
+		{Action: "COMMENTED", Comment: &general},
+		{Action: "COMMENTED", Comment: &anchored, CommentAnchor: &api.CommentAnchor{Path: "src/app.js", Line: 543}},
+		// The feed repeats replies as activities of their own.
+		{Action: "COMMENTED", Comment: &reply},
+		{Action: "RESCOPED"},
+	}
+
+	entries := commentsFromActivities(activities)
+
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3 (reply must not be duplicated)", len(entries))
+	}
+	if entries[0].Comment.ID != 1 || entries[0].Anchor != nil {
+		t.Errorf("first entry = %+v, want the general comment", entries[0].Comment)
+	}
+	if entries[1].Comment.ID != 2 || entries[1].Depth != 0 {
+		t.Errorf("second entry = %+v, want the anchored root comment", entries[1].Comment)
+	}
+	if entries[2].Comment.ID != 3 || entries[2].Depth != 1 {
+		t.Errorf("third entry = %+v (depth %d), want the reply at depth 1", entries[2].Comment, entries[2].Depth)
+	}
+	if entries[2].Anchor == nil || entries[2].Anchor.Line != 543 {
+		t.Error("reply did not inherit its parent's anchor")
+	}
+}
+
+func TestCommentsFromActivitiesOrdersByLocation(t *testing.T) {
+	activities := []api.Activity{
+		{Action: "COMMENTED", Comment: &api.Comment{ID: 1, CreatedDate: 100}, CommentAnchor: &api.CommentAnchor{Path: "b.js", Line: 10}},
+		{Action: "COMMENTED", Comment: &api.Comment{ID: 2, CreatedDate: 200}, CommentAnchor: &api.CommentAnchor{Path: "a.js", Line: 20}},
+		{Action: "COMMENTED", Comment: &api.Comment{ID: 3, CreatedDate: 300}, CommentAnchor: &api.CommentAnchor{Path: "a.js", Line: 5}},
+		{Action: "COMMENTED", Comment: &api.Comment{ID: 4, CreatedDate: 400}},
+	}
+
+	entries := commentsFromActivities(activities)
+
+	var order []int
+	for _, e := range entries {
+		order = append(order, e.Comment.ID)
+	}
+	want := []int{4, 3, 2, 1}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order = %v, want %v (general first, then path and line)", order, want)
+		}
+	}
+}
+
+func TestFilterEntriesByFileKeepsReplies(t *testing.T) {
+	entries := []commentEntry{
+		{Comment: api.Comment{ID: 1}},
+		{Comment: api.Comment{ID: 2}, Anchor: &api.CommentAnchor{Path: "src/app.js", Line: 5}},
+		{Comment: api.Comment{ID: 3}, Anchor: &api.CommentAnchor{Path: "src/app.js", Line: 5}, Depth: 1},
+		{Comment: api.Comment{ID: 4}, Anchor: &api.CommentAnchor{Path: "src/toolbar.vue", Line: 9}},
+	}
+
+	filtered := filterEntriesByFile(entries, "app.js")
+
+	if len(filtered) != 2 || filtered[0].Comment.ID != 2 || filtered[1].Comment.ID != 3 {
+		t.Fatalf("filtered = %+v, want the app.js thread with its reply", filtered)
+	}
+}
+
+func TestDescribeTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		spec   commentSpec
+		anchor *api.CommentAnchor
+		want   string
+	}{
+		{
+			name: "general",
+			spec: commentSpec{Body: "x"},
+			want: "pull request comment",
+		},
+		{
+			name:   "file",
+			spec:   commentSpec{Body: "x", File: "a.js"},
+			anchor: &api.CommentAnchor{Path: "a.js"},
+			want:   "file comment on a.js",
+		},
+		{
+			name:   "line task",
+			spec:   commentSpec{Body: "x", File: "a.js", Line: 5, Blocker: true},
+			anchor: &api.CommentAnchor{Path: "a.js", Line: 5, LineType: api.SegmentAdded, FileType: api.FileTypeTo},
+			want:   "a.js:5 [ADDED/TO] [task]",
+		},
+		{
+			name: "reply",
+			spec: commentSpec{Body: "x", ReplyTo: 42},
+			want: "reply to comment #42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := describeTarget(tt.spec, tt.anchor); got != tt.want {
+				t.Errorf("describeTarget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/pr_info.go
+++ b/cmd/pr_info.go
@@ -205,6 +205,9 @@ var prActivityCmd = &cobra.Command{
 			detail := ""
 			if a.Comment != nil {
 				detail = cmdutil.Truncate(a.Comment.Text, 60)
+				if loc := a.CommentAnchor.Location(); loc != "" {
+					detail = loc + "  " + detail
+				}
 			}
 			fmt.Printf("%s  %s  %s  %s\n", date, a.User.Name, action, detail)
 		}

--- a/cmd/pr_review.go
+++ b/cmd/pr_review.go
@@ -16,8 +16,12 @@ Review actions:
   --approve (-a)           Approve the pull request
   --request-changes (-r)   Request changes (sets NEEDS_WORK status)
   --comment (-c)           Add a comment without changing approval status
+  --discard-pending        Drop your unpublished (pending) review comments
 
-If no action is specified, --comment is assumed when --body is provided.`,
+If no action is specified, --comment is assumed when --body is provided.
+
+Inline comments are posted with 'atl pr comment --file --line'. Pending
+comments drafted with '--pending' are published from the pull request page.`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -54,6 +58,18 @@ If no action is specified, --comment is assumed when --body is provided.`,
 		requestChanges, _ := cmd.Flags().GetBool("request-changes")
 		comment, _ := cmd.Flags().GetBool("comment")
 		body, _ := cmd.Flags().GetString("body")
+		discardPending, _ := cmd.Flags().GetBool("discard-pending")
+
+		if discardPending {
+			if approve || requestChanges || comment || body != "" {
+				return fmt.Errorf("--discard-pending cannot be combined with other review actions")
+			}
+			if err := client.DiscardPendingReview(ctx, project, repo, prID); err != nil {
+				return fmt.Errorf("discarding pending review: %w", err)
+			}
+			fmt.Printf("Discarded pending review comments on PR #%d\n", prID)
+			return nil
+		}
 
 		actionCount := 0
 		if approve {
@@ -220,4 +236,5 @@ func init() {
 	prReviewCmd.Flags().BoolP("request-changes", "r", false, "Request changes")
 	prReviewCmd.Flags().BoolP("comment", "c", false, "Add comment only")
 	prReviewCmd.Flags().StringP("body", "b", "", "Comment text")
+	prReviewCmd.Flags().Bool("discard-pending", false, "Discard your unpublished review comments")
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -72,7 +72,8 @@ What works right now.
 | `atl pr list [project/repo]` | List pull requests |
 | `atl pr view <project/repo> <id>` | View PR details |
 | `atl pr diff <project/repo> <id>` | Show PR diff |
-| `atl pr comment <project/repo> <id> <text>` | Add comment |
+| `atl pr comment <project/repo> <id> <text>` | Add comment, general or inline |
+| `atl pr comments <project/repo> <id>` | List comments grouped by file and line |
 | `atl pr merge <project/repo> <id>` | Merge PR |
 | `atl pr status` | Show PR status summary |
 
@@ -86,6 +87,43 @@ What works right now.
 **Merge options:**
 - `--force` - Merge without approvals
 - `--delete-branch` - Delete source branch after merge
+
+### Inline review comments
+
+`atl pr comment` anchors a comment to a line of the diff when given `--file`
+and `--line`, the same way the web UI does. The line type (ADDED, REMOVED,
+CONTEXT) and the file side are resolved from the pull request diff, so a path
+and a line number are enough:
+
+```bash
+atl pr comment MYPROJ/myrepo 140 -f src/app.js -L 543 -b "this allocation leaks"
+atl pr comment MYPROJ/myrepo 140 -f src/app.js -L 120 --side old -b "why drop this?"
+atl pr comment MYPROJ/myrepo 140 --reply 331 -b "fixed in a1b2c3d"
+```
+
+- `--line` counts in the new file; `--side old` targets a deleted line.
+- Only lines the diff touches can be anchored; the error lists the commentable
+  ranges of the file.
+- `--blocker` posts a task that blocks the merge.
+- `--pending` keeps the comment unpublished, visible only to you until you
+  publish the review from the pull request page. `atl pr review
+  --discard-pending` drops the drafts.
+- `--batch findings.json` posts a whole review at once, and `--dry-run` prints
+  the resolved anchors without posting. Every anchor is resolved before the
+  first comment is posted, so a bad path or line cannot half-post a batch.
+
+Batch entries are `{body, file, line, side, reply_to, blocker, pending}`:
+
+```json
+[
+  {"file": "src/app.js", "line": 543, "body": "this allocation leaks", "blocker": true},
+  {"file": "src/app.js", "line": 120, "side": "old", "body": "why drop this?"},
+  {"body": "NAK, see inline"}
+]
+```
+
+`atl pr comments` reads a review back, grouped by file and line, with the IDs
+`--reply` takes and `[TASK]`, `[PENDING]` and `[ORPHANED]` markers.
 
 ---
 

--- a/internal/cmdutil/constants.go
+++ b/internal/cmdutil/constants.go
@@ -8,6 +8,7 @@ import (
 const (
 	DefaultLimit         = 25
 	DefaultChildrenLimit = 50
+	DefaultActivityLimit = 100
 
 	TitleTruncateShort  = 40
 	TitleTruncateNormal = 50

--- a/skills/atl-cli/SKILL.md
+++ b/skills/atl-cli/SKILL.md
@@ -33,7 +33,9 @@ atl
     ├── list [proj/repo]              # --state --author --base --head --limit
     ├── view [proj/repo] [id]
     ├── diff [proj/repo] [id]
-    ├── comment [proj/repo] [id] [text]
+    ├── comment [proj/repo] [id] [text]  # -b -F -f -L --side --reply --blocker --pending --batch --dry-run
+    ├── comments [proj/repo] [id]     # -f --pending --limit --json
+    ├── review [proj/repo] [id]       # -a -r -c -b --discard-pending
     ├── merge [proj/repo] [id]        # --force --delete-branch
     └── status                        # Your PRs & reviews
 ```
@@ -135,6 +137,49 @@ atl pr status
 ```
 
 | `--state` | OPEN, MERGED, DECLINED, ALL |
+
+## Inline Review Comments
+
+Anchor a comment to a line of the diff. `--line` counts in the NEW file;
+`--side old` targets a line the PR deletes. ADDED/REMOVED/CONTEXT and the
+file side are resolved from the diff -- never hand-write them.
+
+```bash
+atl pr comment PROJ/repo 140 -f src/app.py -L 42 -b "this leaks"       # inline
+atl pr comment PROJ/repo 140 -f src/app.py -L 42 --side old -b "why?"  # deleted line
+atl pr comment PROJ/repo 140 -f src/app.py -b "file-level note"        # whole file
+atl pr comment PROJ/repo 140 --reply 331 -b "fixed in a1b2c3d"     # thread reply
+atl pr comment PROJ/repo 140 --blocker -f src/app.py -L 42 -b "..."    # merge-blocking task
+atl pr comments PROJ/repo 140                                          # read the review back
+```
+
+Only lines the diff touches (changed lines plus surrounding context) can be
+anchored -- the error lists the file's commentable ranges. Reply IDs come from
+`atl pr comments`.
+
+### Agent review workflow
+
+Post a whole review from JSON. Anchors are all resolved before anything is
+posted, so a bad path or line cannot half-post a batch.
+
+```json
+[
+  {"file": "src/app.py", "line": 42, "body": "leaks here", "blocker": true},
+  {"file": "src/app.py", "line": 17, "side": "old", "body": "why drop this?"},
+  {"body": "NAK, see inline"}
+]
+```
+
+```bash
+atl pr comment PROJ/repo 140 --batch findings.json --dry-run   # check anchors first
+atl pr comment PROJ/repo 140 --batch findings.json --pending   # draft, nobody notified
+atl pr comments PROJ/repo 140 --pending                        # review the draft
+atl pr review PROJ/repo 140 --discard-pending                  # drop the draft
+```
+
+`--pending` comments stay invisible to everyone else until published from the
+PR page in the browser. Default to `--pending` for agent-authored reviews: a
+public comment notifies every reviewer and cannot be unsent.
 
 ## Pitfalls
 


### PR DESCRIPTION
## What

`atl pr` could read review threads but never write one anchored to a diff line.
Only the top-level PR comment API was wired up, so line-level review — the thing
reviewers actually do — had to happen in the web UI.

Two commits:

1. **Inline review comments anchored to diff lines.** New `api/bitbucket_diff.go`
   parses the structured diff and resolves a `file:line` into the anchor shape the
   server expects (`fromHash`/`toHash`, `path`, `line`, `lineType`, `fileType`).
   `api/bitbucket_comment.go` posts, replies, and lists with that anchor.
   `cmd/pr_comment.go` exposes it, including `--batch` for multiple comments in one
   pass and `--pending` so drafts stay invisible to reviewers until submitted.
   `pr activity` now shows anchors too.

2. **Comment lifecycle.** Edit and delete by comment ID, so a wrong draft is
   fixable instead of permanent.

## Why this shape

The anchor resolution was derived from the real server behaviour, not the docs:
the read path was verified to reproduce an existing bot-authored anchor exactly
before the write path was attempted. `--pending` was validated end to end — public
comment count was unchanged after the draft round-trip.

One bug surfaced during that verification and is fixed here: the `/review`
endpoint returns plain comments, not the thread wrapper the first implementation
assumed.

## Test

- `api/bitbucket_diff_test.go` — diff parsing and anchor resolution
- `api/bitbucket_comment_test.go` — request shapes
- `cmd/pr_comment_test.go` — batch parsing, validation, thread grouping
- `go build ./...` and `go test ./...` clean; `gofmt` clean

Examples in the skill doc and fixtures are instance-agnostic, per the existing
`chore: abstract instance-specific examples` policy.